### PR TITLE
Modify NPM build script quotes to address issues on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "webpack --mode=production && npm run sass && cpx 'dist/*.{css,js,map,woff,woff2}' viewer/ && cpx 'dist/injectables/**/*.{css,js,map}' viewer/injectables/",
-    "dev": "webpack --mode=development && npm run sass && cpx 'dist/*.{css,js,map,woff,woff2}' viewer/ && cpx 'dist/injectables/**/*.{css,js,map}' viewer/injectables/",
+    "build": "webpack --mode=production && npm run sass && cpx \"dist/*.{css,js,map,woff,woff2}\" viewer/ && cpx \"dist/injectables/**/*.{css,js,map}\" viewer/injectables/",
+    "dev": "webpack --mode=development && npm run sass && cpx \"dist/*.{css,js,map,woff,woff2}\" viewer/ && cpx \"dist/injectables/**/*.{css,js,map}\" viewer/injectables/",
     "sass": "node-sass --source-map true src/styles/sass/ -o dist/",
-    "examples": "rimraf examples/streamed/readers/viewer && cpx 'viewer/*.{html,css,js,map,woff,woff2}' examples/streamed/readers/viewer && cpx 'viewer/readium-css/*.{css,js}' examples/streamed/readers/viewer/readium-css && cpx 'viewer/fonts/*/*.{css,woff,woff2}' examples/streamed/readers/viewer/fonts && cpx 'viewer/injectables/**/*.{css,js,map}' examples/streamed/readers/viewer/injectables && cpx 'injectables/**/*.{css,js,map}' examples/streamed/readers/viewer/injectables ",
+    "examples": "rimraf examples/streamed/readers/viewer && cpx \"viewer/*.{html,css,js,map,woff,woff2}\" examples/streamed/readers/viewer && cpx \"viewer/readium-css/*.{css,js}\" examples/streamed/readers/viewer/readium-css && cpx \"viewer/fonts/*/*.{css,woff,woff2}\" examples/streamed/readers/viewer/fonts && cpx \"viewer/injectables/**/*.{css,js,map}\" examples/streamed/readers/viewer/injectables && cpx \"injectables/**/*.{css,js,map}\" examples/streamed/readers/viewer/injectables",
     "streamed": "node \"./examples/streamed/server/server-cli.inlinesourcemap.js\" ./examples/streamed/epubs/",
     "clean": "rimraf node_modules lib dist examples/streamed/readers/viewer",
     "about": "echo 'Do not update @types/parse5 to version 5 or else it will break jsdom typings!'"


### PR DESCRIPTION
Single quotes have known problematic behaviour under Windows; in this case, the various `cpx` commands were silently failing when run as part of the NPM scripts on Windows.

This turns them into escaped double quotes (`\"`), which seems to be the recommended approach on Windows.