### PR TITLE
Selection-level highlighting of TTS words (initial, for comment)

### DIFF
--- a/src/model/Locator.ts
+++ b/src/model/Locator.ts
@@ -58,6 +58,7 @@ export interface ISelectionInfo {
     cleanText: string;
     rawText: string;
     color: string;
+    range: Range;
 }
 
 export interface IRangeInfo {

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -824,7 +824,7 @@ export default class TextHighlighter {
             //     var highlight = this.createHighlight(self.dom(self.el).getWindow(), selectionInfo,  TextHighlighter.hexToColor(this.getColor()),true, marker)
             //     this.options.onAfterHighlight(highlight, marker);
             // }
-            this.ttsDelegate.speak(selectionInfo as any);
+            this.ttsDelegate.speak(selectionInfo as any, this.getColor());
             
         }
     };

--- a/src/modules/highlight/common/selection.ts
+++ b/src/modules/highlight/common/selection.ts
@@ -75,6 +75,7 @@ export interface ISelectionInfo {
     rangeInfo: IRangeInfo;
     cleanText: string;
     rawText: string;
+    range: Range;
 }
 
 export function sameSelections(sel1: ISelectionInfo, sel2: ISelectionInfo): boolean {

--- a/src/modules/highlight/renderer/iframe/selection.ts
+++ b/src/modules/highlight/renderer/iframe/selection.ts
@@ -92,7 +92,7 @@ export function getCurrentSelectionInfo(
     // selection.removeAllRanges();
     //     // selection.addRange(range);
 
-    return { rangeInfo, cleanText, rawText };
+    return { rangeInfo, cleanText, rawText, range };
 }
 
 export function createOrderedRange(startNode: Node, startOffset: number, endNode: Node, endOffset: number):


### PR DESCRIPTION
This adds by-word highlighting for selections that fill within the same block (selections spanning multiple blocks are more complex and will need further exploration). It's rough right now, but at a point where I think comments would be useful. In particular, I am fairly new to TypeScript, and want to make sure code I contribute is appropriately idiomatic in how it's being used.

Thoughts/observations:
- the raw `Range` was added to the `ISelectionInfo` interface. I suspect this may not be appropriate long-term, and the `ISelectionInfo` / `IRangeInfo` interfaces should have additional functionality added to support what's done with the `Range` in the `speak` function of `TTSModule`.
- the approach taken uses `Splitting.js` in a somewhat different way, and does some DOM manipulation to temporarily replace the text within the selection with word-splitting markup, then restore the original content.
- I think initial refactoring should focus on extracting a common model of operation for the use case (highlighting individual words as TTS speaks); this is complicated by the realities of how the Selection/Range features work, but for the moment there appear to be three main areas to consider:
  - speaking and highlighting the entire current resource, word by word (implemented)
  - speaking and highlighting a selection within a single block (implemented)
  - speaking and highlighting a selection spanning multiple blocks (not implemented)