### PR TITLE
TS declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",
-  "main": "src/index.js",
-  "typings": "src/index.ts",
+  "main": "dist/reader.js",
+  "typings": "dist/index.d.ts",
   "engines": {
     "node": ">8.0.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "moduleResolution": "node",
     "outDir": "./dist/",
     "sourceMap": true,
+    "declaration": true,
     "preserveConstEnums": true,
     "strictNullChecks": false,
     "target": "es6"


### PR DESCRIPTION
This PR is to include Typescript declarations in the build output. To do this I enabled `declarations` in the `tsconfig.json`, and then had to update where the `package.json` was telling consumers the main `.js` and `.d.ts` files were. As a consequence, you can now simply import from the package root:
```js
import D2Reader from '@d-i-t-a/reader';
```
instead of importing from the `dist` folder directly:
```js
import D2Reader from '@d-i-t-a/reader/dist/reader';
```
and you now get full type defs when using the library:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/4398775/111988875-5dd6df80-8b11-11eb-81f4-936572d99869.png">

I think this should be fully backwards compatible because you can still import from `@d-i-t-a/reader/dist/reader`, but note that typescript will not find the declaration files in that case, because they are under the name `index.d.ts`. I couldn't find a setting to rename them to `reader.d.ts`, but if you import from the package root then the `"types": "dist/index.d.ts"` property in `package.json` fixes that issue by associating the two files. 

One way to fix that would be to change the `output.filename` in webpack to `index.js` for the reader, then you would automatically find the `index.d.ts` no matter how it was imported, but that would be a breaking change so I avoided it.