### PR TITLE
Small typefix

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -80,9 +80,9 @@ export interface IFrameNavigatorConfig {
 export interface Injectable {
     type: string;
     url?: string;
-    r2after: boolean;
-    r2before: boolean;
-    r2default: boolean;
+    r2after?: boolean;
+    r2before?: boolean;
+    r2default?: boolean;
     fontFamily?: string;
     systemFont?: boolean;
     appearance?: string;


### PR DESCRIPTION
Here is a small change to the `Injectable` types. I am not _certain_ that it is meant to be this way, but it appears so based on the examples not always having these values defined. I was getting a type error from not defining them myself. Just a small thing, but figured I'd make a quick PR in case it's helpful. Feel free to reject if not