### PR TITLE
Remove option chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "mark.js": "^8.11.1",
         "promise-polyfill": "^8.2.0",
         "sanitize-html": "^2.3.3",
-        "ts-optchain": "^0.1.8",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -9259,14 +9258,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-optchain": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ts-optchain/-/ts-optchain-0.1.8.tgz",
-      "integrity": "sha512-crvloFKZlPIysdVcP7Ej1w4HijBx7NmLdeorqfxOvt87DcUIbhKV4ZaSgCL+IQ+zzTgDx5zDuNHRvUbTIr9aqw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -17316,11 +17307,6 @@
           }
         }
       }
-    },
-    "ts-optchain": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ts-optchain/-/ts-optchain-0.1.8.tgz",
-      "integrity": "sha512-crvloFKZlPIysdVcP7Ej1w4HijBx7NmLdeorqfxOvt87DcUIbhKV4ZaSgCL+IQ+zzTgDx5zDuNHRvUbTIr9aqw=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mark.js": "^8.11.1",
     "promise-polyfill": "^8.2.0",
     "sanitize-html": "^2.3.3",
-    "ts-optchain": "^0.1.8",
     "whatwg-fetch": "^3.6.2"
   },
   "browserslist": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,23 +58,23 @@ export async function unload() {
   document.body.onscroll = () => {};
   R2Navigator.stop();
   R2Settings.stop();
-  if (oc(R2Navigator.rights).enableTTS(false)) {
+  if (R2Navigator.rights?.enableTTS) {
     R2TTSSettings.stop();
     TTSModuleInstance.stop();
   }
-  if (oc(R2Navigator.rights).enableBookmarks(false)) {
+  if (R2Navigator.rights?.enableBookmarks) {
     BookmarkModuleInstance.stop();
   }
-  if (oc(R2Navigator.rights).enableAnnotations(false)) {
+  if (R2Navigator.rights?.enableAnnotations) {
     AnnotationModuleInstance.stop();
   }
-  if (oc(R2Navigator.rights).enableSearch(false)) {
+  if (R2Navigator.rights?.enableSearch) {
     SearchModuleInstance.stop();
   }
-  if (oc(R2Navigator.rights).enableContentProtection(false)) {
+  if (R2Navigator.rights?.enableContentProtection) {
     ContentProtectionModuleInstance.stop();
   }
-  if (oc(R2Navigator.rights).enableTimeline(false)) {
+  if (R2Navigator.rights?.enableTimeline) {
     TimelineModuleInstance.stop();
   }
 }
@@ -104,7 +104,7 @@ export function resumeReadAloud() {
 }
 
 export async function saveBookmark() {
-  if (oc(R2Navigator.rights).enableBookmarks(false)) {
+  if (R2Navigator.rights?.enableBookmarks) {
     if (IS_DEV) {
       console.log("saveBookmark");
     }
@@ -112,7 +112,7 @@ export async function saveBookmark() {
   }
 }
 export async function deleteBookmark(bookmark) {
-  if (oc(R2Navigator.rights).enableBookmarks(false)) {
+  if (R2Navigator.rights?.enableBookmarks) {
     if (IS_DEV) {
       console.log("deleteBookmark");
     }
@@ -120,7 +120,7 @@ export async function deleteBookmark(bookmark) {
   }
 }
 export async function deleteAnnotation(highlight) {
-  if (oc(R2Navigator.rights).enableAnnotations(false)) {
+  if (R2Navigator.rights?.enableAnnotations) {
     if (IS_DEV) {
       console.log("deleteAnnotation");
     }
@@ -128,7 +128,7 @@ export async function deleteAnnotation(highlight) {
   }
 }
 export async function addAnnotation(highlight) {
-  if (oc(R2Navigator.rights).enableAnnotations(false)) {
+  if (R2Navigator.rights?.enableAnnotations) {
     if (IS_DEV) {
       console.log("addAnnotation");
     }
@@ -142,7 +142,7 @@ export async function tableOfContents() {
   return await R2Navigator.tableOfContents();
 }
 export async function bookmarks() {
-  if (oc(R2Navigator.rights).enableBookmarks(false)) {
+  if (R2Navigator.rights?.enableBookmarks) {
     if (IS_DEV) {
       console.log("bookmarks");
     }
@@ -152,7 +152,7 @@ export async function bookmarks() {
   }
 }
 export async function annotations() {
-  if (oc(R2Navigator.rights).enableAnnotations(false)) {
+  if (R2Navigator.rights?.enableAnnotations) {
     if (IS_DEV) {
       console.log("annotations");
     }
@@ -163,7 +163,7 @@ export async function annotations() {
 }
 
 export async function search(term, current) {
-  if (oc(R2Navigator.rights).enableSearch(false)) {
+  if (R2Navigator.rights?.enableSearch) {
     if (IS_DEV) {
       console.log("search");
     }
@@ -173,7 +173,7 @@ export async function search(term, current) {
   }
 }
 export async function goToSearchIndex(href, index, current) {
-  if (oc(R2Navigator.rights).enableSearch(false)) {
+  if (R2Navigator.rights?.enableSearch) {
     if (IS_DEV) {
       console.log("goToSearchIndex");
     }
@@ -181,7 +181,7 @@ export async function goToSearchIndex(href, index, current) {
   }
 }
 export async function goToSearchID(href, index, current) {
-  if (oc(R2Navigator.rights).enableSearch(false)) {
+  if (R2Navigator.rights?.enableSearch) {
     if (IS_DEV) {
       console.log("goToSearchID");
     }
@@ -189,7 +189,7 @@ export async function goToSearchID(href, index, current) {
   }
 }
 export async function clearSearch() {
-  if (oc(R2Navigator.rights).enableSearch(false)) {
+  if (R2Navigator.rights?.enableSearch) {
     if (IS_DEV) {
       console.log("clearSearch");
     }
@@ -244,7 +244,7 @@ export async function increase(incremental) {
     (incremental === "pitch" ||
       incremental === "rate" ||
       incremental === "volume") &&
-    oc(R2Navigator.rights).enableTTS(false)
+    (R2Navigator.rights?.enableTTS ?? false)
   ) {
     if (IS_DEV) {
       console.log("increase " + incremental);
@@ -262,7 +262,7 @@ export async function decrease(incremental) {
     (incremental === "pitch" ||
       incremental === "rate" ||
       incremental === "volume") &&
-    oc(R2Navigator.rights).enableTTS(false)
+    (R2Navigator.rights?.enableTTS ?? false)
   ) {
     if (IS_DEV) {
       console.log("decrease " + incremental);
@@ -282,7 +282,7 @@ export async function publisher(on) {
   R2Settings.publisher(on);
 }
 export async function resetTTSSettings() {
-  if (oc(R2Navigator.rights).enableTTS(false)) {
+  if (R2Navigator.rights?.enableTTS) {
     if (IS_DEV) {
       console.log("resetSettings");
     }
@@ -290,7 +290,7 @@ export async function resetTTSSettings() {
   }
 }
 export async function applyTTSSettings(ttsSettings) {
-  if (oc(R2Navigator.rights).enableTTS(false)) {
+  if (R2Navigator.rights?.enableTTS) {
     if (IS_DEV) {
       console.log("applyTTSSettings");
     }
@@ -299,7 +299,7 @@ export async function applyTTSSettings(ttsSettings) {
 }
 
 export async function ttsSet(key, value) {
-  if (oc(R2Navigator.rights).enableTTS(false)) {
+  if (R2Navigator.rights?.enableTTS) {
     if (IS_DEV) {
       console.log("set " + key + " value " + value);
     }
@@ -307,7 +307,7 @@ export async function ttsSet(key, value) {
   }
 }
 export async function preferredVoice(value) {
-  if (oc(R2Navigator.rights).enableTTS(false)) {
+  if (R2Navigator.rights?.enableTTS) {
     R2TTSSettings.preferredVoice(value);
   }
 }
@@ -395,9 +395,8 @@ export async function snapToElement(value) {
 export async function load(config: ReaderConfig): Promise<any> {
   var browsers: string[] = [];
 
-  if (oc(config.protection).enforceSupportedBrowsers(false)) {
-    oc(config.protection)
-      .supportedBrowsers([])
+  if (config.protection?.enforceSupportedBrowsers) {
+    (config.protection?.supportedBrowsers ?? [])
       .forEach((browser: string) => {
         browsers.push("last 1 " + browser + " version");
       });
@@ -408,9 +407,9 @@ export async function load(config: ReaderConfig): Promise<any> {
   });
 
   if (
-    (oc(config.protection).enforceSupportedBrowsers(false) &&
+    ((config.protection?.enforceSupportedBrowsers ?? false) &&
       supportedBrowsers.test(navigator.userAgent)) ||
-    oc(config.protection).enforceSupportedBrowsers(false) === false
+    (config.protection?.enforceSupportedBrowsers ?? false) === false
   ) {
     var mainElement = document.getElementById("D2Reader-Container");
     var headerMenu = document.getElementById("headerMenu");
@@ -436,19 +435,19 @@ export async function load(config: ReaderConfig): Promise<any> {
       store
     );
 
-    if (oc(publication.metadata.rendition).layout("unknown") === "fixed") {
+    if ((publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
       config.rights.enableAnnotations = false;
       config.rights.enableSearch = false;
       config.rights.enableTTS = false;
       // config.protection.enableObfuscation = false;
     }
 
-    if (oc(config.rights).autoGeneratePositions(true)) {
+    if ((config.rights?.autoGeneratePositions ?? true)) {
       var startPosition = 0;
       var totalContentLength = 0;
       var positions = [];
       publication.readingOrder.map(async (link, index) => {
-        if (oc(publication.metadata.rendition).layout("unknown") === "fixed") {
+        if ((publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
           const locator: Locator = {
             href: link.href,
             locations: {
@@ -487,7 +486,7 @@ export async function load(config: ReaderConfig): Promise<any> {
         }
         if (index + 1 === publication.readingOrder.length) {
           if (
-            oc(publication.metadata.rendition).layout("unknown") !== "fixed"
+            (publication.metadata.rendition?.layout ?? "unknown") !== "fixed"
           ) {
             publication.readingOrder.map(async (link) => {
               if (IS_DEV) console.log(totalContentLength);
@@ -527,7 +526,7 @@ export async function load(config: ReaderConfig): Promise<any> {
       material: config.material,
       api: config.api,
       layout:
-        oc(publication.metadata.rendition).layout("unknown") === "fixed"
+        (publication.metadata.rendition?.layout ?? "unknown") === "fixed"
           ? "fixed"
           : "reflowable",
     });
@@ -547,14 +546,14 @@ export async function load(config: ReaderConfig): Promise<any> {
       rights: config.rights,
       tts: config.tts,
       injectables:
-        oc(publication.metadata.rendition).layout("unknown") === "fixed"
+        (publication.metadata.rendition?.layout ?? "unknown") === "fixed"
           ? []
           : config.injectables,
       attributes: config.attributes,
     });
 
     // Highlighter
-    if (oc(publication.metadata.rendition).layout("unknown") !== "fixed") {
+    if ((publication.metadata.rendition?.layout ?? "unknown") !== "fixed") {
       D2Highlighter = await TextHighlighter.create({
         delegate: R2Navigator,
         config: config.highlighter,
@@ -562,7 +561,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
 
     // Bookmark Module
-    if (oc(config.rights).enableBookmarks(false)) {
+    if (config.rights?.enableBookmarks) {
       BookmarkModuleInstance = await BookmarkModule.create({
         annotator: annotator,
         headerMenu: headerMenu,
@@ -574,7 +573,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
 
     // Annotation Module
-    if (oc(config.rights).enableAnnotations(false)) {
+    if (config.rights?.enableAnnotations) {
       AnnotationModuleInstance = await AnnotationModule.create({
         annotator: annotator,
         headerMenu: headerMenu,
@@ -588,7 +587,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
 
     // TTS Module
-    if (oc(config.rights).enableTTS(false)) {
+    if (config.rights?.enableTTS) {
       R2TTSSettings = await TTSSettings.create({
         store: settingsStore,
         initialTTSSettings: config.tts,
@@ -605,7 +604,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
 
     // Search Module
-    if (oc(config.rights).enableSearch(false)) {
+    if (config.rights?.enableSearch) {
       SearchModule.create({
         headerMenu: headerMenu,
         delegate: R2Navigator,
@@ -618,7 +617,7 @@ export async function load(config: ReaderConfig): Promise<any> {
       });
     }
     // Timeline Module
-    if (oc(config.rights).enableTimeline(false)) {
+    if (config.rights?.enableTimeline) {
       TimelineModule.create({
         publication: publication,
         delegate: R2Navigator,
@@ -628,7 +627,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
 
     // Content Protection Module
-    if (oc(config.rights).enableContentProtection(false)) {
+    if (config.rights?.enableContentProtection) {
       ContentProtectionModule.create({
         delegate: R2Navigator,
         protection: config.protection,

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export async function increase(incremental) {
     (incremental === "pitch" ||
       incremental === "rate" ||
       incremental === "volume") &&
-    (R2Navigator.rights?.enableTTS ?? false)
+    R2Navigator.rights?.enableTTS
   ) {
     if (IS_DEV) {
       console.log("increase " + incremental);
@@ -261,7 +261,7 @@ export async function decrease(incremental) {
     (incremental === "pitch" ||
       incremental === "rate" ||
       incremental === "volume") &&
-    (R2Navigator.rights?.enableTTS ?? false)
+    R2Navigator.rights?.enableTTS
   ) {
     if (IS_DEV) {
       console.log("decrease " + incremental);
@@ -405,9 +405,9 @@ export async function load(config: ReaderConfig): Promise<any> {
   });
 
   if (
-    ((config.protection?.enforceSupportedBrowsers ?? false) &&
+    (config.protection?.enforceSupportedBrowsers &&
       supportedBrowsers.test(navigator.userAgent)) ||
-    (config.protection?.enforceSupportedBrowsers ?? false) === false
+    !config.protection?.enforceSupportedBrowsers
   ) {
     var mainElement = document.getElementById("D2Reader-Container");
     var headerMenu = document.getElementById("headerMenu");

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import BookmarkModule from "./modules/BookmarkModule";
 import { UserSettings } from "./model/user-settings/UserSettings";
 import AnnotationModule from "./modules/AnnotationModule";
 import TTSModule from "./modules/TTS/TTSModule";
-import { oc } from "ts-optchain";
 import { TTSSettings } from "./modules/TTS/TTSSettings";
 import SearchModule from "./modules/search/SearchModule";
 import ContentProtectionModule from "./modules/protection/ContentProtectionModule";
@@ -396,10 +395,9 @@ export async function load(config: ReaderConfig): Promise<any> {
   var browsers: string[] = [];
 
   if (config.protection?.enforceSupportedBrowsers) {
-    (config.protection?.supportedBrowsers ?? [])
-      .forEach((browser: string) => {
-        browsers.push("last 1 " + browser + " version");
-      });
+    (config.protection?.supportedBrowsers ?? []).forEach((browser: string) => {
+      browsers.push("last 1 " + browser + " version");
+    });
   }
   const supportedBrowsers = getUserAgentRegExp({
     browsers: browsers,
@@ -442,7 +440,7 @@ export async function load(config: ReaderConfig): Promise<any> {
       // config.protection.enableObfuscation = false;
     }
 
-    if ((config.rights?.autoGeneratePositions ?? true)) {
+    if (config.rights?.autoGeneratePositions ?? true) {
       var startPosition = 0;
       var totalContentLength = 0;
       var positions = [];

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -414,7 +414,8 @@ export class UserSettings implements IUserSettings {
 
   async applyProperties(): Promise<any> {
     if (
-      (this.view.delegate.publication.metadata.rendition?.layout ?? "unknown") !== "fixed"
+      (this.view.delegate.publication.metadata.rendition?.layout ??
+        "unknown") !== "fixed"
     ) {
       const html = HTMLUtilities.findRequiredIframeElement(
         this.iframe.contentDocument,

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -414,9 +414,7 @@ export class UserSettings implements IUserSettings {
 
   async applyProperties(): Promise<any> {
     if (
-      oc(this.view.delegate.publication.metadata.rendition).layout(
-        "unknown"
-      ) !== "fixed"
+      (this.view.delegate.publication.metadata.rendition?.layout ?? "unknown") !== "fixed"
     ) {
       const html = HTMLUtilities.findRequiredIframeElement(
         this.iframe.contentDocument,

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -30,7 +30,6 @@ import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import { IS_DEV } from "../..";
 import { addEventListenerOptional } from "../../utils/EventHandler";
 import { ReaderUI } from "../../navigator/IFrameNavigator";
-import { oc } from "ts-optchain";
 import ReflowableBookView from "../../views/ReflowableBookView";
 import FixedBookView from "../../views/FixedBookView";
 import BookView from "../../views/BookView";
@@ -623,7 +622,7 @@ export class UserSettings implements IUserSettings {
   }
 
   private renderControls(element: HTMLElement): void {
-    if (oc(this.material).settings.fontSize(false)) {
+    if (this.material?.settings.fontSize) {
       this.fontSizeButtons = {};
       for (const fontSizeName of ["decrease", "increase"]) {
         this.fontSizeButtons[fontSizeName] = HTMLUtilities.findElement(
@@ -634,7 +633,7 @@ export class UserSettings implements IUserSettings {
     } else {
       HTMLUtilities.findElement(element, "#container-view-fontsize")?.remove();
     }
-    if (oc(this.material).settings.fontFamily(false)) {
+    if (this.material?.settings.fontFamily) {
       this.fontButtons = {};
       this.fontButtons[0] = HTMLUtilities.findElement(
         element,
@@ -668,7 +667,7 @@ export class UserSettings implements IUserSettings {
       )?.remove();
     }
 
-    if (oc(this.material).settings.appearance(false)) {
+    if (this.material?.settings.appearance) {
       this.themeButtons = {};
       this.themeButtons[0] = HTMLUtilities.findElement(
         element,
@@ -701,7 +700,7 @@ export class UserSettings implements IUserSettings {
       )?.remove();
     }
 
-    if (oc(this.material).settings.scroll(false)) {
+    if (this.material?.settings.scroll) {
       this.viewButtons = {};
       this.viewButtons[0] = HTMLUtilities.findElement(
         element,
@@ -737,7 +736,7 @@ export class UserSettings implements IUserSettings {
   }
 
   private async setupEvents(): Promise<void> {
-    if (oc(this.material).settings.fontSize(false)) {
+    if (this.material?.settings.fontSize) {
       addEventListenerOptional(
         this.fontSizeButtons["decrease"],
         "click",
@@ -770,7 +769,7 @@ export class UserSettings implements IUserSettings {
       );
     }
 
-    if (oc(this.material).settings.fontFamily(false)) {
+    if (this.material?.settings.fontFamily) {
       for (
         let index = 0;
         index < UserSettings.fontFamilyValues.length;
@@ -794,7 +793,7 @@ export class UserSettings implements IUserSettings {
       }
     }
 
-    if (oc(this.material).settings.appearance(false)) {
+    if (this.material?.settings.appearance) {
       for (
         let index = 0;
         index < UserSettings.appearanceValues.length;
@@ -817,7 +816,7 @@ export class UserSettings implements IUserSettings {
       }
     }
 
-    if (oc(this.material).settings.scroll(false)) {
+    if (this.material?.settings.scroll) {
       for (let index = 0; index < 2; index++) {
         const button = this.viewButtons[index];
         if (button) {
@@ -841,7 +840,7 @@ export class UserSettings implements IUserSettings {
   }
 
   private async updateFontButtons(): Promise<void> {
-    if (oc(this.material).settings.fontFamily(false)) {
+    if (this.material?.settings.fontFamily) {
       for (
         let index = 0;
         index < UserSettings.fontFamilyValues.length;
@@ -865,7 +864,7 @@ export class UserSettings implements IUserSettings {
   }
 
   private async updateViewButtons(): Promise<void> {
-    if (oc(this.material).settings.scroll(false)) {
+    if (this.material?.settings.scroll) {
       for (let index = 0; index < 2; index++) {
         this.viewButtons[index].className = this.viewButtons[
           index
@@ -901,7 +900,7 @@ export class UserSettings implements IUserSettings {
       UserSettings.fontFamilyValues.push(fontFamily);
       this.applyProperties();
 
-      if (this.settingsView && oc(this.material).settings.fontFamily(false)) {
+      if (this.settingsView && this.material?.settings.fontFamily) {
         const index = UserSettings.fontFamilyValues.length - 1;
         this.fontButtons[index] = HTMLUtilities.findElement(
           this.settingsView,
@@ -1301,7 +1300,7 @@ export class UserSettings implements IUserSettings {
     ).value = this.verticalScroll;
     this.saveProperty(this.userProperties.getByRef(ReadiumCSS.SCROLL_REF));
     this.applyProperties();
-    if (oc(this.material).settings.scroll(false)) {
+    if (this.material?.settings.scroll) {
       this.updateViewButtons();
     }
     this.view.setMode(scroll);

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -136,7 +136,7 @@ export default class AnnotationModule implements ReaderModule {
   initialize() {
     return new Promise(async (resolve) => {
       await (document as any).fonts.ready;
-      if (oc(this.rights).enableAnnotations(false)) {
+      if (this.rights?.enableAnnotations) {
         setTimeout(() => {
           this.drawHighlights();
         }, 300);
@@ -165,7 +165,7 @@ export default class AnnotationModule implements ReaderModule {
       }
       await this.showHighlights();
       await this.drawHighlights();
-      if (oc(this.delegate.rights).enableMaterial(false)) {
+      if (this.delegate.rights?.enableMaterial) {
         toast({ html: "highlight deleted" });
       }
       return deleted;
@@ -295,7 +295,7 @@ export default class AnnotationModule implements ReaderModule {
   }
 
   async drawHighlights(search: boolean = true): Promise<void> {
-    if (oc(this.rights).enableAnnotations(false) && this.highlighter) {
+    if ((this.rights?.enableAnnotations ?? false) && this.highlighter) {
       if (this.api) {
         let highlights: Array<any> = [];
         if (this.annotator) {
@@ -393,7 +393,7 @@ export default class AnnotationModule implements ReaderModule {
         this.highlighter.setColor(this.config.initialAnnotationColor);
       }
     }
-    if (search && oc(this.rights).enableSearch(false)) {
+    if (search && (this.rights?.enableSearch ?? false)) {
       this.delegate.searchModule.drawSearch();
     }
   }
@@ -537,8 +537,8 @@ export default class AnnotationModule implements ReaderModule {
                 bookmarkItem.appendChild(bookmarkLink);
                 if (
                   (self.delegate.sideNavExpanded &&
-                    oc(self.delegate.rights).enableMaterial(false)) ||
-                  !oc(self.delegate.rights).enableMaterial(false)
+                    (self.delegate.rights?.enableMaterial ?? false)) ||
+                  !(self.delegate.rights?.enableMaterial ?? false)
                 ) {
                   let bookmarkDeleteLink: HTMLElement = document.createElement(
                     "button"

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -35,7 +35,6 @@ import { IS_DEV } from "..";
 import { toast } from "materialize-css";
 import { icons as IconLib } from "../utils/IconLib";
 import { v4 as uuid } from "uuid";
-import { oc } from "ts-optchain";
 
 export type Highlight = (highlight: Annotation) => Promise<Annotation>;
 
@@ -389,7 +388,7 @@ export default class AnnotationModule implements ReaderModule {
           });
         }
       }
-      if (this.config && oc(this.config).initialAnnotationColor !== undefined) {
+      if (this.config && this.config?.initialAnnotationColor !== undefined) {
         this.highlighter.setColor(this.config.initialAnnotationColor);
       }
     }

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -295,7 +295,7 @@ export default class AnnotationModule implements ReaderModule {
   }
 
   async drawHighlights(search: boolean = true): Promise<void> {
-    if ((this.rights?.enableAnnotations ?? false) && this.highlighter) {
+    if (this.rights?.enableAnnotations && this.highlighter) {
       if (this.api) {
         let highlights: Array<any> = [];
         if (this.annotator) {
@@ -393,7 +393,7 @@ export default class AnnotationModule implements ReaderModule {
         this.highlighter.setColor(this.config.initialAnnotationColor);
       }
     }
-    if (search && (this.rights?.enableSearch ?? false)) {
+    if (search && this.rights?.enableSearch) {
       this.delegate.searchModule.drawSearch();
     }
   }
@@ -537,8 +537,8 @@ export default class AnnotationModule implements ReaderModule {
                 bookmarkItem.appendChild(bookmarkLink);
                 if (
                   (self.delegate.sideNavExpanded &&
-                    (self.delegate.rights?.enableMaterial ?? false)) ||
-                  !(self.delegate.rights?.enableMaterial ?? false)
+                    self.delegate.rights?.enableMaterial) ||
+                  !self.delegate.rights?.enableMaterial
                 ) {
                   let bookmarkDeleteLink: HTMLElement = document.createElement(
                     "button"

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -28,7 +28,6 @@ import { Bookmark, Locator } from "../model/Locator";
 import { IS_DEV } from "..";
 import { toast } from "materialize-css";
 import { v4 as uuid } from "uuid";
-import { oc } from "ts-optchain";
 
 export type AddBookmark = (bookmark: Bookmark) => Promise<Bookmark>;
 export type DeleteBookmark = (bookmark: Bookmark) => Promise<Bookmark>;

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -361,8 +361,8 @@ export default class BookmarkModule implements ReaderModule {
                 bookmarkItem.appendChild(bookmarkLink);
                 if (
                   (self.delegate.sideNavExpanded &&
-                    (self.delegate.rights?.enableMaterial ?? false)) ||
-                  !(self.delegate.rights?.enableMaterial ?? false)
+                    self.delegate.rights?.enableMaterial) ||
+                  !self.delegate.rights?.enableMaterial
                 ) {
                   let bookmarkDeleteLink: HTMLElement = document.createElement(
                     "button"

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -115,7 +115,7 @@ export default class BookmarkModule implements ReaderModule {
         this.headerMenu,
         "#menu-button-bookmark"
       ) as HTMLLinkElement;
-      if (oc(this.rights).enableMaterial(false)) {
+      if (this.rights?.enableMaterial) {
         if (menuBookmark)
           menuBookmark.parentElement.style.removeProperty("display");
         if (menuBookmark)
@@ -152,7 +152,7 @@ export default class BookmarkModule implements ReaderModule {
             console.log("Bookmark deleted " + JSON.stringify(deleted));
           }
           await this.showBookmarks();
-          if (oc(this.delegate.rights).enableMaterial(false)) {
+          if (this.delegate.rights?.enableMaterial) {
             toast({ html: "bookmark deleted" });
           }
           return deleted;
@@ -164,7 +164,7 @@ export default class BookmarkModule implements ReaderModule {
           console.log("Bookmark deleted " + JSON.stringify(deleted));
         }
         await this.showBookmarks();
-        if (oc(this.delegate.rights).enableMaterial(false)) {
+        if (this.delegate.rights?.enableMaterial) {
           toast({ html: "bookmark deleted" });
         }
         return deleted;
@@ -215,7 +215,7 @@ export default class BookmarkModule implements ReaderModule {
             if (IS_DEV) {
               console.log("Bookmark added " + JSON.stringify(saved));
             }
-            if (oc(this.delegate.rights).enableMaterial(false)) {
+            if (this.delegate.rights?.enableMaterial) {
               toast({ html: "bookmark added" });
             }
             await this.showBookmarks();
@@ -227,14 +227,14 @@ export default class BookmarkModule implements ReaderModule {
           if (IS_DEV) {
             console.log("Bookmark added " + JSON.stringify(saved));
           }
-          if (oc(this.delegate.rights).enableMaterial(false)) {
+          if (this.delegate.rights?.enableMaterial) {
             toast({ html: "bookmark added" });
           }
           await this.showBookmarks();
           return saved;
         }
       } else {
-        if (oc(this.delegate.rights).enableMaterial(false)) {
+        if (this.delegate.rights?.enableMaterial) {
           toast({ html: "bookmark exists" });
         }
       }
@@ -362,8 +362,8 @@ export default class BookmarkModule implements ReaderModule {
                 bookmarkItem.appendChild(bookmarkLink);
                 if (
                   (self.delegate.sideNavExpanded &&
-                    oc(self.delegate.rights).enableMaterial(false)) ||
-                  !oc(self.delegate.rights).enableMaterial(false)
+                    (self.delegate.rights?.enableMaterial ?? false)) ||
+                  !(self.delegate.rights?.enableMaterial ?? false)
                 ) {
                   let bookmarkDeleteLink: HTMLElement = document.createElement(
                     "button"

--- a/src/modules/TTS/TTSModule.ts
+++ b/src/modules/TTS/TTSModule.ts
@@ -26,7 +26,6 @@ import {
   addEventListenerOptional,
   removeEventListenerOptional,
 } from "../../utils/EventHandler";
-import { oc } from "ts-optchain";
 import * as sanitize from "sanitize-html";
 import IFrameNavigator, { ReaderRights } from "../../navigator/IFrameNavigator";
 import TextHighlighter from "../highlight/TextHighlighter";
@@ -399,18 +398,20 @@ export default class TTSModule implements ReaderModule {
       var spokenWordCleaned = word.replace(/[^a-zA-Z0-9 ]/g, "");
       if (IS_DEV) console.log("spokenWordCleaned", spokenWordCleaned);
 
-      var splittingWord = self.splittingResult[self.index] as HTMLElement;
-      var splittingWordCleaned = oc(splittingWord)
-        .dataset.word("")
-        .replace(/[^a-zA-Z0-9 ]/g, "");
+      let splittingWord = self.splittingResult[self.index] as HTMLElement;
+      var splittingWordCleaned = splittingWord?.dataset.word.replace(
+        /[^a-zA-Z0-9 ]/g,
+        ""
+      );
       if (IS_DEV) console.log("splittingWordCleaned", splittingWordCleaned);
 
       if (splittingWordCleaned.length === 0) {
         self.index++;
         splittingWord = self.splittingResult[self.index] as HTMLElement;
-        splittingWordCleaned = oc(splittingWord)
-          .dataset.word("")
-          .replace(/[^a-zA-Z0-9 ]/g, "");
+        splittingWordCleaned = splittingWord?.dataset.word.replace(
+          /[^a-zA-Z0-9 ]/g,
+          ""
+        );
         if (IS_DEV) console.log("splittingWordCleaned", splittingWordCleaned);
       }
 

--- a/src/modules/TTS/TTSModule.ts
+++ b/src/modules/TTS/TTSModule.ts
@@ -538,7 +538,7 @@ export default class TTSModule implements ReaderModule {
         this.headerMenu,
         "#menu-button-tts"
       ) as HTMLLinkElement;
-      if (oc(this.rights).enableMaterial(false)) {
+      if (this.rights?.enableMaterial) {
         if (menuTTS) menuTTS.parentElement.style.removeProperty("display");
       } else {
         if (menuTTS) menuTTS.parentElement.style.setProperty("display", "none");

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -990,42 +990,41 @@ export default class TextHighlighter {
         }
       }
 
-      if ((this.config?.selectionMenuItems ?? [])) {
-        (this.config?.selectionMenuItems ?? [])
-          .forEach((menuItem) => {
-            var itemElement = document.getElementById(menuItem.id);
-            var self = this;
+      if (this.config?.selectionMenuItems ?? []) {
+        (this.config?.selectionMenuItems ?? []).forEach((menuItem) => {
+          var itemElement = document.getElementById(menuItem.id);
+          var self = this;
 
-            function itemEvent() {
-              itemElement.removeEventListener("click", itemEvent);
+          function itemEvent() {
+            itemElement.removeEventListener("click", itemEvent);
 
-              function getCssSelector(element: Element): string {
-                const options = {
-                  className: (str: string) => {
-                    return _blacklistIdClassForCssSelectors.indexOf(str) < 0;
-                  },
-                  idName: (str: string) => {
-                    return _blacklistIdClassForCssSelectors.indexOf(str) < 0;
-                  },
-                };
-                return uniqueCssSelector(
-                  element,
-                  self.delegate.iframe.contentDocument,
-                  options
-                );
-              }
-
-              const selectionInfo = getCurrentSelectionInfo(
-                self.delegate.iframe.contentWindow,
-                getCssSelector
+            function getCssSelector(element: Element): string {
+              const options = {
+                className: (str: string) => {
+                  return _blacklistIdClassForCssSelectors.indexOf(str) < 0;
+                },
+                idName: (str: string) => {
+                  return _blacklistIdClassForCssSelectors.indexOf(str) < 0;
+                },
+              };
+              return uniqueCssSelector(
+                element,
+                self.delegate.iframe.contentDocument,
+                options
               );
-              if (selectionInfo !== undefined) {
-                menuItem.callback(selectionInfo.cleanText);
-              }
-              self.callbackComplete();
             }
-            itemElement.addEventListener("click", itemEvent);
-          });
+
+            const selectionInfo = getCurrentSelectionInfo(
+              self.delegate.iframe.contentWindow,
+              getCssSelector
+            );
+            if (selectionInfo !== undefined) {
+              menuItem.callback(selectionInfo.cleanText);
+            }
+            self.callbackComplete();
+          }
+          itemElement.addEventListener("click", itemEvent);
+        });
       }
     }
   }
@@ -1741,8 +1740,10 @@ export default class TextHighlighter {
 
   isIOS() {
     // Second test is needed for iOS 13+
-    return navigator.userAgent.match(/iPhone|iPad|iPod/i) != null ||
-    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    return (
+      navigator.userAgent.match(/iPhone|iPad|iPod/i) != null ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+    );
   }
   isAndroid() {
     return navigator.userAgent.match(/Android/i) != null;

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -47,7 +47,6 @@ import { icons } from "../../utils/IconLib";
 import IFrameNavigator, {
   SelectionMenuItem,
 } from "../../navigator/IFrameNavigator";
-import { oc } from "ts-optchain";
 
 export const ID_HIGHLIGHTS_CONTAINER = "R2_ID_HIGHLIGHTS_CONTAINER";
 export const CLASS_HIGHLIGHT_CONTAINER = "R2_CLASS_HIGHLIGHT_CONTAINER";
@@ -883,7 +882,7 @@ export default class TextHighlighter {
   selectionMenuClosed = debounce(() => {
     if (this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = false;
-      if (this.config?.api && oc(this.config).api.selectionMenuClose(false)) {
+      if (this.config?.api && this.config?.api.selectionMenuClose) {
         this.config.api.selectionMenuClose();
       }
     }

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -876,7 +876,7 @@ export default class TextHighlighter {
     if (!this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = true;
       if (
-        oc(this.config).api(false) &&
+        (this.config?.api ?? false) &&
         oc(this.config).api.selectionMenuOpen(false)
       ) {
         this.config.api.selectionMenuOpen();
@@ -887,7 +887,7 @@ export default class TextHighlighter {
     if (this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = false;
       if (
-        oc(this.config).api(false) &&
+        (this.config?.api ?? false) &&
         oc(this.config).api.selectionMenuClose(false)
       ) {
         this.config.api.selectionMenuClose();
@@ -905,7 +905,7 @@ export default class TextHighlighter {
     var toolbox = document.getElementById("highlight-toolbox");
 
     toolbox.style.top =
-      rect.top + oc(this.delegate.attributes).navHeight(0) + "px";
+      rect.top + (this.delegate.attributes?.navHeight ?? 0) + "px";
     toolbox.style.left = (rect.right - rect.left) / 2 + rect.left + "px";
   }
 
@@ -923,7 +923,7 @@ export default class TextHighlighter {
       var underlineIcon = document.getElementById("underlineIcon");
       var colorIcon = document.getElementById("colorIcon");
       var speakIcon = document.getElementById("speakIcon");
-      if (oc(this.delegate.rights).enableAnnotations(false)) {
+      if (this.delegate.rights?.enableAnnotations) {
         if (highlightIcon) {
           highlightIcon.style.display = "unset";
           if (colorIcon) {
@@ -976,7 +976,7 @@ export default class TextHighlighter {
           colorIcon.style.setProperty("display", "none");
         }
       }
-      if (oc(this.delegate.rights).enableTTS(false)) {
+      if (this.delegate.rights?.enableTTS) {
         if (speakIcon) {
           function speakEvent() {
             speakIcon.removeEventListener("click", speakEvent);
@@ -990,9 +990,8 @@ export default class TextHighlighter {
         }
       }
 
-      if (oc(this.config).selectionMenuItems([])) {
-        oc(this.config)
-          .selectionMenuItems([])
+      if ((this.config?.selectionMenuItems ?? [])) {
+        (this.config?.selectionMenuItems ?? [])
           .forEach((menuItem) => {
             var itemElement = document.getElementById(menuItem.id);
             var self = this;
@@ -1076,7 +1075,7 @@ export default class TextHighlighter {
           marker
         );
         this.options.onAfterHighlight(highlight, marker);
-        if (oc(this.delegate.rights).enableAnnotations(false)) {
+        if (this.delegate.rights?.enableAnnotations) {
           this.delegate.annotationModule.saveAnnotation(highlight, marker);
         }
       }
@@ -1092,7 +1091,7 @@ export default class TextHighlighter {
   }
 
   speak() {
-    if (oc(this.delegate.rights).enableTTS(false)) {
+    if (this.delegate.rights?.enableTTS) {
       var self = this;
       function getCssSelector(element: Element): string {
         const options = {
@@ -1133,12 +1132,12 @@ export default class TextHighlighter {
     }
   }
   stopReadAloud() {
-    if (oc(this.delegate.rights).enableTTS(false)) {
+    if (this.delegate.rights?.enableTTS) {
       this.doneSpeaking();
     }
   }
   speakAll() {
-    if (oc(this.delegate.rights).enableTTS(false)) {
+    if (this.delegate.rights?.enableTTS) {
       var self = this;
       function getCssSelector(element: Element): string {
         const options = {
@@ -1206,7 +1205,7 @@ export default class TextHighlighter {
   }
 
   doneSpeaking(reload: boolean = false) {
-    if (oc(this.delegate.rights).enableTTS(false)) {
+    if (this.delegate.rights?.enableTTS) {
       this.toolboxHide();
       this.dom(this.delegate.iframe.contentDocument.body).removeAllRanges();
       this.delegate.ttsModule.cancel();
@@ -1742,10 +1741,8 @@ export default class TextHighlighter {
 
   isIOS() {
     // Second test is needed for iOS 13+
-    return (
-      navigator.userAgent.match(/iPhone|iPad|iPod/i) != null ||
-      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-    );
+    return navigator.userAgent.match(/iPhone|iPad|iPod/i) != null ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
   }
   isAndroid() {
     return navigator.userAgent.match(/Android/i) != null;
@@ -1898,7 +1895,7 @@ export default class TextHighlighter {
         var toolbox = document.getElementById("highlight-toolbox");
         // toolbox.style.top = ev.clientY + 74 + 'px';
         toolbox.style.top =
-          ev.clientY + oc(this.delegate.attributes).navHeight(0) + "px";
+          ev.clientY + (this.delegate.attributes?.navHeight ?? 0) + "px";
         toolbox.style.left = ev.clientX + "px";
 
         if (getComputedStyle(toolbox).display === "none") {

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -875,10 +875,7 @@ export default class TextHighlighter {
   selectionMenuOpened = debounce(() => {
     if (!this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = true;
-      if (
-        (this.config?.api ?? false) &&
-        oc(this.config).api.selectionMenuOpen(false)
-      ) {
+      if (this.config?.api && this.config?.api?.selectionMenuOpen) {
         this.config.api.selectionMenuOpen();
       }
     }
@@ -886,10 +883,7 @@ export default class TextHighlighter {
   selectionMenuClosed = debounce(() => {
     if (this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = false;
-      if (
-        (this.config?.api ?? false) &&
-        oc(this.config).api.selectionMenuClose(false)
-      ) {
+      if (this.config?.api && oc(this.config).api.selectionMenuClose(false)) {
         this.config.api.selectionMenuClose();
       }
     }

--- a/src/modules/positions/TimelineModule.ts
+++ b/src/modules/positions/TimelineModule.ts
@@ -24,7 +24,6 @@ import IFrameNavigator from "../../navigator/IFrameNavigator";
 import { addEventListenerOptional } from "../../utils/EventHandler";
 import ReaderModule from "../ReaderModule";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
-import { oc } from "ts-optchain";
 
 export interface TimelineModuleConfig {
   publication: Publication;
@@ -130,7 +129,7 @@ export default class TimelineModule implements ReaderModule {
           event.preventDefault();
           event.stopPropagation();
           var position;
-          if ((this.delegate.rights?.autoGeneratePositions ?? true)) {
+          if (this.delegate.rights?.autoGeneratePositions ?? true) {
             position = {
               ...this.publication.positions.filter(
                 (el: Locator) => el.href === link.href

--- a/src/modules/positions/TimelineModule.ts
+++ b/src/modules/positions/TimelineModule.ts
@@ -78,7 +78,7 @@ export default class TimelineModule implements ReaderModule {
 
       let locator = this.delegate.currentLocator();
       if (
-        (this.delegate.rights?.enableMaterial ?? false) &&
+        this.delegate.rights?.enableMaterial &&
         (this.delegate.rights?.autoGeneratePositions ?? true) &&
         this.publication.positions
       ) {

--- a/src/modules/positions/TimelineModule.ts
+++ b/src/modules/positions/TimelineModule.ts
@@ -62,13 +62,13 @@ export default class TimelineModule implements ReaderModule {
       document,
       "#container-view-timeline"
     ) as HTMLDivElement;
-    if (oc(this.delegate.rights).enableMaterial(false)) {
+    if (this.delegate.rights?.enableMaterial) {
       this.positionSlider = HTMLUtilities.findElement(
         document,
         "#positionSlider"
       ) as HTMLInputElement;
     }
-    if (!oc(this.delegate.rights).autoGeneratePositions(true)) {
+    if (!(this.delegate.rights?.autoGeneratePositions ?? true)) {
       this.positionSlider.style.display = "none";
     }
   }
@@ -79,8 +79,8 @@ export default class TimelineModule implements ReaderModule {
 
       let locator = this.delegate.currentLocator();
       if (
-        oc(this.delegate.rights).enableMaterial(false) &&
-        oc(this.delegate.rights).autoGeneratePositions(true) &&
+        (this.delegate.rights?.enableMaterial ?? false) &&
+        (this.delegate.rights?.autoGeneratePositions ?? true) &&
         this.publication.positions
       ) {
         this.positionSlider.value = locator.locations.position.toString();
@@ -130,7 +130,7 @@ export default class TimelineModule implements ReaderModule {
           event.preventDefault();
           event.stopPropagation();
           var position;
-          if (oc(this.delegate.rights).autoGeneratePositions(true)) {
+          if ((this.delegate.rights?.autoGeneratePositions ?? true)) {
             position = {
               ...this.publication.positions.filter(
                 (el: Locator) => el.href === link.href

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -67,7 +67,7 @@ export default class ContentProtectionModule implements ReaderModule {
   protected async start(): Promise<void> {
     this.delegate.contentProtectionModule = this;
 
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       this.securityContainer = HTMLUtilities.findElement(
         document,
         "#container-view-security"
@@ -93,7 +93,7 @@ export default class ContentProtectionModule implements ReaderModule {
     }
     this.mutationObserver.disconnect();
 
-    if (oc(this.protection).disableKeys(false)) {
+    if (this.protection?.disableKeys) {
       removeEventListenerOptional(
         this.delegate.mainElement,
         "keydown",
@@ -130,7 +130,7 @@ export default class ContentProtectionModule implements ReaderModule {
       removeEventListenerOptional(document, "keydown", this.disableSave);
     }
 
-    if (oc(this.protection).disableCopy(false)) {
+    if (this.protection?.disableCopy) {
       removeEventListenerOptional(
         this.delegate.mainElement,
         "copy",
@@ -200,7 +200,7 @@ export default class ContentProtectionModule implements ReaderModule {
       removeEventListenerOptional(window, "cut", this.preventCopy);
       removeEventListenerOptional(document, "cut", this.preventCopy);
     }
-    if (oc(this.protection).disablePrint(false)) {
+    if (this.protection?.disablePrint) {
       removeEventListenerOptional(
         this.delegate.mainElement,
         "beforeprint",
@@ -278,7 +278,7 @@ export default class ContentProtectionModule implements ReaderModule {
         this.afterPrint.bind(this)
       );
     }
-    if (oc(this.protection).disableContextMenu(false)) {
+    if (this.protection?.disableContextMenu) {
       removeEventListenerOptional(
         this.delegate.mainElement,
         "contextmenu",
@@ -314,10 +314,10 @@ export default class ContentProtectionModule implements ReaderModule {
       removeEventListenerOptional(window, "contextmenu", this.disableContext);
       removeEventListenerOptional(document, "contextmenu", this.disableContext);
     }
-    if (oc(this.protection).hideTargetUrl(false)) {
+    if (this.protection?.hideTargetUrl) {
       this.hideTargetUrls(false);
     }
-    if (oc(this.protection).disableDrag(false)) {
+    if (this.protection?.disableDrag) {
       this.preventDrag(false);
     }
 
@@ -325,7 +325,7 @@ export default class ContentProtectionModule implements ReaderModule {
   }
 
   observe(): any {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       if (this.securityContainer.hasAttribute("style")) {
         this.isHacked = true;
       }
@@ -342,7 +342,7 @@ export default class ContentProtectionModule implements ReaderModule {
   }
 
   public async deactivate() {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       this.observe();
       this.rects.forEach((rect) =>
         this.deactivateRect(rect, this.securityContainer, this.isHacked)
@@ -351,7 +351,7 @@ export default class ContentProtectionModule implements ReaderModule {
   }
 
   public async activate() {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       this.observe();
       const body = HTMLUtilities.findRequiredIframeElement(
         this.delegate.iframe.contentDocument,
@@ -365,7 +365,7 @@ export default class ContentProtectionModule implements ReaderModule {
   }
   private setupEvents(): void {
     var self = this;
-    if (oc(this.protection).detectInspect(false)) {
+    if (this.protection?.detectInspect) {
       var checkStatus = "off";
       var div = document.createElement("div");
       Object.defineProperty(div, "id", {
@@ -378,14 +378,14 @@ export default class ContentProtectionModule implements ReaderModule {
         checkStatus = "off";
         console.log(div);
         if (checkStatus === "on") {
-          if (oc(self.protection).clearOnInspect(false)) {
+          if (self.protection?.clearOnInspect) {
             console.clear();
             window.localStorage.clear();
             window.sessionStorage.clear();
             window.location.replace(window.location.origin);
           }
           if (
-            oc(self.protection).api(false) &&
+            (self.protection?.api ?? false) &&
             oc(self.protection).api.inspectDetected(false)
           ) {
             self.protection.api.inspectDetected();
@@ -395,7 +395,7 @@ export default class ContentProtectionModule implements ReaderModule {
       });
     }
 
-    if (oc(this.protection).disableKeys(false)) {
+    if (this.protection?.disableKeys) {
       addEventListenerOptional(
         this.delegate.mainElement,
         "keydown",
@@ -456,7 +456,7 @@ export default class ContentProtectionModule implements ReaderModule {
       addEventListenerOptional(window, "keydown", this.disableSave);
       addEventListenerOptional(document, "keydown", this.disableSave);
     }
-    if (oc(this.protection).disableCopy(false)) {
+    if (this.protection?.disableCopy) {
       addEventListenerOptional(
         this.delegate.mainElement,
         "copy",
@@ -570,7 +570,7 @@ export default class ContentProtectionModule implements ReaderModule {
       addEventListenerOptional(document, "cut", this.preventCopy);
     }
 
-    if (oc(this.protection).disablePrint(false)) {
+    if (this.protection?.disablePrint) {
       addEventListenerOptional(
         this.delegate.mainElement,
         "beforeprint",
@@ -707,7 +707,7 @@ export default class ContentProtectionModule implements ReaderModule {
         this.afterPrint.bind(this)
       );
     }
-    if (oc(this.protection).disableContextMenu(false)) {
+    if (this.protection?.disableContextMenu) {
       addEventListenerOptional(
         this.delegate.mainElement,
         "contextmenu",
@@ -771,16 +771,16 @@ export default class ContentProtectionModule implements ReaderModule {
   }
 
   initializeResource() {
-    if (oc(this.protection).hideTargetUrl(false)) {
+    if (this.protection?.hideTargetUrl) {
       this.hideTargetUrls(true);
     }
-    if (oc(this.protection).disableDrag(false)) {
+    if (this.protection?.disableDrag) {
       this.preventDrag(true);
     }
   }
 
   public async initialize() {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       return new Promise<void>(async (resolve) => {
         await (document as any).fonts.ready;
         const body = HTMLUtilities.findRequiredIframeElement(
@@ -817,7 +817,7 @@ export default class ContentProtectionModule implements ReaderModule {
     );
   }
   handleResize() {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       const onDoResize = debounce(() => {
         this.calcRects(this.rects);
         if (this.rects !== undefined) {
@@ -1019,7 +1019,7 @@ export default class ContentProtectionModule implements ReaderModule {
   }
 
   recalculate(delay: number = 0) {
-    if (oc(this.protection).enableObfuscation(false)) {
+    if (this.protection?.enableObfuscation) {
       const onDoResize = debounce(() => {
         this.calcRects(this.rects);
         if (this.rects !== undefined) {

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -385,7 +385,7 @@ export default class ContentProtectionModule implements ReaderModule {
             window.location.replace(window.location.origin);
           }
           if (
-            (self.protection?.api ?? false) &&
+            self.protection?.api &&
             oc(self.protection).api.inspectDetected(false)
           ) {
             self.protection.api.inspectDetected();

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -26,7 +26,6 @@ import {
 } from "../../utils/EventHandler";
 import { debounce } from "debounce";
 import { IS_DEV } from "../..";
-import { oc } from "ts-optchain";
 
 export interface ContentProtectionModuleConfig {
   delegate: IFrameNavigator;
@@ -384,10 +383,7 @@ export default class ContentProtectionModule implements ReaderModule {
             window.sessionStorage.clear();
             window.location.replace(window.location.origin);
           }
-          if (
-            self.protection?.api &&
-            oc(self.protection).api.inspectDetected(false)
-          ) {
+          if (self.protection?.api && self.protection?.api.inspectDetected) {
             self.protection.api.inspectDetected();
           }
         }

--- a/src/modules/search/SearchModule.ts
+++ b/src/modules/search/SearchModule.ts
@@ -29,7 +29,6 @@ import { Locator, Locations } from "../../model/Locator";
 import { IS_DEV } from "../..";
 import { searchDocDomSeek, reset } from "./searchWithDomSeek";
 import TextHighlighter from "../highlight/TextHighlighter";
-import { oc } from "ts-optchain";
 
 export interface SearchConfig {
   color: string;

--- a/src/modules/search/SearchModule.ts
+++ b/src/modules/search/SearchModule.ts
@@ -152,13 +152,13 @@ export default class SearchModule implements ReaderModule {
     self.currentChapterSearchResult = [];
     self.currentHighlights = [];
     var localSearchResultChapter: any = [];
-    if (oc(this.delegate.rights).enableContentProtection(false)) {
+    if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.deactivate();
     }
     await this.searchAndPaintChapter(searchVal, index, async (result) => {
       localSearchResultChapter = result;
       goToResultPage(1);
-      if (oc(this.delegate.rights).enableContentProtection(false)) {
+      if (this.delegate.rights?.enableContentProtection) {
         this.delegate.contentProtectionModule.recalculate(200);
       }
     });
@@ -290,10 +290,10 @@ export default class SearchModule implements ReaderModule {
 
     // clear search results // needs more works
     this.highlighter.destroyAllhighlights(this.delegate.iframe.contentDocument);
-    if (oc(this.delegate.rights).enableAnnotations(false)) {
+    if (this.delegate.rights?.enableAnnotations) {
       this.delegate.annotationModule.drawHighlights();
     } else {
-      if (oc(this.delegate.rights).enableSearch(false)) {
+      if (this.delegate.rights?.enableSearch) {
         this.drawSearch();
       }
     }
@@ -352,7 +352,7 @@ export default class SearchModule implements ReaderModule {
     this.currentChapterSearchResult = [];
     this.currentHighlights = [];
     this.highlighter.destroyAllhighlights(this.delegate.iframe.contentDocument);
-    if (oc(this.delegate.rights).enableAnnotations(false)) {
+    if (this.delegate.rights?.enableAnnotations) {
       this.delegate.annotationModule.drawHighlights();
     }
   }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -679,7 +679,7 @@ export default class IFrameNavigator implements Navigator {
           self.mTabs = Tabs.init(tabs);
         }
         if (this.headerMenu) {
-          if (!(this.rights?.enableBookmarks ?? false)) {
+          if (!this.rights?.enableBookmarks) {
             if (menuBookmark)
               menuBookmark.parentElement.style.setProperty("display", "none");
             var sideNavSectionBookmarks = HTMLUtilities.findElement(
@@ -689,7 +689,7 @@ export default class IFrameNavigator implements Navigator {
             if (sideNavSectionBookmarks)
               sideNavSectionBookmarks.style.setProperty("display", "none");
           }
-          if (!(this.rights?.enableAnnotations ?? false)) {
+          if (!this.rights?.enableAnnotations) {
             var sideNavSectionHighlights = HTMLUtilities.findElement(
               this.headerMenu,
               "#sidenav-section-highlights"
@@ -697,11 +697,11 @@ export default class IFrameNavigator implements Navigator {
             if (sideNavSectionHighlights)
               sideNavSectionHighlights.style.setProperty("display", "none");
           }
-          if (!(this.rights?.enableTTS ?? false)) {
+          if (!this.rights?.enableTTS) {
             if (menuTTS)
               menuTTS.parentElement.style.setProperty("display", "none");
           }
-          if (!(this.rights?.enableSearch ?? false)) {
+          if (!this.rights?.enableSearch) {
             menuSearch.parentElement.style.removeProperty("display");
           }
           if (
@@ -1524,10 +1524,7 @@ export default class IFrameNavigator implements Navigator {
       }
       setTimeout(() => {
         const body = this.iframe.contentDocument.body;
-        if (
-          (this.rights?.enableTTS ?? false) &&
-          (this.tts?.enableSplitter ?? false)
-        ) {
+        if (this.rights?.enableTTS && this.tts?.enableSplitter) {
           Splitting({
             target: body,
             by: "lines",

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -351,7 +351,7 @@ export default class IFrameNavigator implements Navigator {
     removeEventListenerOptional(window, "resize", this.onResize);
     removeEventListenerOptional(this.iframe, "resize", this.onResize);
 
-    if (oc(this.rights).enableMaterial(false)) {
+    if (this.rights?.enableMaterial) {
       if (this.mDropdowns) {
         this.mDropdowns.forEach((element) => {
           (element as any).destroy();
@@ -415,7 +415,7 @@ export default class IFrameNavigator implements Navigator {
         spread_left.appendChild(this.iframe);
 
         if (
-          oc(this.publication.metadata.rendition).layout("unknown") === "fixed"
+          (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
         ) {
           var spread_right = document.createElement("div");
           spreads.appendChild(spread_right);
@@ -433,12 +433,12 @@ export default class IFrameNavigator implements Navigator {
           spread_right.style.boxShadow = "0 0 8px 2px #ccc";
         } else {
           this.iframe.style.paddingTop =
-            oc(this.attributes).iframePaddingTop(0) + "px";
+            (this.attributes?.iframePaddingTop ?? 0) + "px";
         }
       }
 
       if (
-        oc(this.publication.metadata.rendition).layout("unknown") === "fixed"
+        (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
       ) {
         var wrapper = HTMLUtilities.findRequiredElement(
           mainElement,
@@ -647,7 +647,7 @@ export default class IFrameNavigator implements Navigator {
           "#menu-button-bookmark"
         ) as HTMLLinkElement;
       }
-      if (oc(this.rights).enableMaterial(false)) {
+      if (this.rights?.enableMaterial) {
         let elements = document.querySelectorAll(".sidenav");
         if (elements) {
           self.mSidenav = Sidenav.init(elements, {
@@ -680,7 +680,7 @@ export default class IFrameNavigator implements Navigator {
           self.mTabs = Tabs.init(tabs);
         }
         if (this.headerMenu) {
-          if (!oc(this.rights).enableBookmarks(false)) {
+          if (!(this.rights?.enableBookmarks ?? false)) {
             if (menuBookmark)
               menuBookmark.parentElement.style.setProperty("display", "none");
             var sideNavSectionBookmarks = HTMLUtilities.findElement(
@@ -690,7 +690,7 @@ export default class IFrameNavigator implements Navigator {
             if (sideNavSectionBookmarks)
               sideNavSectionBookmarks.style.setProperty("display", "none");
           }
-          if (!oc(this.rights).enableAnnotations(false)) {
+          if (!(this.rights?.enableAnnotations ?? false)) {
             var sideNavSectionHighlights = HTMLUtilities.findElement(
               this.headerMenu,
               "#sidenav-section-highlights"
@@ -698,18 +698,16 @@ export default class IFrameNavigator implements Navigator {
             if (sideNavSectionHighlights)
               sideNavSectionHighlights.style.setProperty("display", "none");
           }
-          if (!oc(this.rights).enableTTS(false)) {
+          if (!(this.rights?.enableTTS ?? false)) {
             if (menuTTS)
               menuTTS.parentElement.style.setProperty("display", "none");
           }
-          if (!oc(this.rights).enableSearch(false)) {
+          if (!(this.rights?.enableSearch ?? false)) {
             menuSearch.parentElement.style.removeProperty("display");
           }
           if (
             menuSearch &&
-            oc(this.view.delegate.publication.metadata.rendition).layout(
-              "unknown"
-            ) === "fixed"
+            (this.view.delegate.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
           ) {
             menuSearch.parentElement.style.setProperty("display", "none");
           }
@@ -730,7 +728,7 @@ export default class IFrameNavigator implements Navigator {
           self.annotationModule.drawHighlights();
           // self.annotationModule.drawIndicators()
         } else {
-          if (oc(this.rights).enableSearch(false)) {
+          if (this.rights?.enableSearch) {
             await this.highlighter.destroyAllhighlights(
               this.iframe.contentDocument
             );
@@ -1139,7 +1137,7 @@ export default class IFrameNavigator implements Navigator {
         if (this.annotationModule !== undefined) {
           this.annotationModule.drawHighlights();
         } else {
-          if (oc(this.rights).enableSearch(false)) {
+          if (this.rights?.enableSearch) {
             await this.highlighter.destroyAllhighlights(
               this.iframe.contentDocument
             );
@@ -1527,15 +1525,15 @@ export default class IFrameNavigator implements Navigator {
       setTimeout(() => {
         const body = this.iframe.contentDocument.body;
         if (
-          oc(this.rights).enableTTS(false) &&
-          oc(this.tts).enableSplitter(false)
+          (this.rights?.enableTTS ?? false) &&
+          (this.tts?.enableSplitter ?? false)
         ) {
           Splitting({
             target: body,
             by: "lines",
           });
         }
-        if (oc(this.rights).enableContentProtection(false)) {
+        if (this.rights?.enableContentProtection) {
           setTimeout(async () => {
             if (this.contentProtectionModule !== undefined) {
               await this.contentProtectionModule.initialize();
@@ -1553,14 +1551,14 @@ export default class IFrameNavigator implements Navigator {
           this.keyboardEventHandler.setupEvents(document);
         }
         if (this.view.layout !== "fixed") {
-          if (oc(this.view).isScrollMode()) {
+          if (this.view?.isScrollMode()) {
             this.view.setIframeHeight(this.iframe);
           }
         }
         if (this.annotationModule !== undefined) {
           this.annotationModule.initialize();
         }
-        if (oc(this.rights).enableTTS(false)) {
+        if (this.rights?.enableTTS) {
           setTimeout(() => {
             const body = this.iframe.contentDocument.body;
             if (this.ttsModule !== undefined) {
@@ -1650,7 +1648,7 @@ export default class IFrameNavigator implements Navigator {
 
     if (this.api && this.api.getContent) {
       if (
-        oc(this.publication.metadata.rendition).layout("unknown") === "fixed"
+        (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
       ) {
         if (even) {
           this.api.getContent(this.currentChapterLink.href).then((content) => {
@@ -1723,7 +1721,7 @@ export default class IFrameNavigator implements Navigator {
           }
           if (
             this.iframe2 &&
-            oc(this.publication.metadata.rendition).layout("unknown") ===
+            (this.publication.metadata.rendition?.layout ?? "unknown") ===
               "fixed"
           ) {
             this.api
@@ -1776,7 +1774,7 @@ export default class IFrameNavigator implements Navigator {
       }
     } else {
       if (
-        oc(this.publication.metadata.rendition).layout("unknown") === "fixed"
+        (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
       ) {
         if (even) {
           if (isSameOrigin) {
@@ -1877,7 +1875,7 @@ export default class IFrameNavigator implements Navigator {
         }
       }
     }
-    if (oc(this.publication.metadata.rendition).layout("unknown") === "fixed") {
+    if ((this.publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
       setTimeout(() => {
         const height = getComputedStyle(
           index === 0 && this.iframe2
@@ -2043,7 +2041,7 @@ export default class IFrameNavigator implements Navigator {
       IFrameNavigator.hideElement(element, control);
     }
     if (element === this.linksMiddle) {
-      if (oc(this.view).isScrollMode()) {
+      if (this.view?.isScrollMode()) {
         IFrameNavigator.showElement(element, control);
       } else {
         IFrameNavigator.hideElement(element, control);
@@ -2077,22 +2075,22 @@ export default class IFrameNavigator implements Navigator {
     event.stopPropagation();
   }
   startReadAloud() {
-    if (oc(this.rights).enableTTS(false)) {
+    if (this.rights?.enableTTS) {
       this.highlighter.speakAll();
     }
   }
   stopReadAloud() {
-    if (oc(this.rights).enableTTS(false)) {
+    if (this.rights?.enableTTS) {
       this.highlighter.stopReadAloud();
     }
   }
   pauseReadAloud() {
-    if (oc(this.rights).enableTTS(false)) {
+    if (this.rights?.enableTTS) {
       this.ttsModule.speakPause();
     }
   }
   resumeReadAloud() {
-    if (oc(this.rights).enableTTS(false)) {
+    if (this.rights?.enableTTS) {
       this.ttsModule.speakResume();
     }
   }
@@ -2151,7 +2149,7 @@ export default class IFrameNavigator implements Navigator {
   currentLocator(): Locator {
     let position;
     if (
-      oc(this.rights).autoGeneratePositions(true) &&
+      (this.rights?.autoGeneratePositions ?? true) &&
       this.publication.positions
     ) {
       let positions = this.publication.positionsByHref(
@@ -2190,7 +2188,7 @@ export default class IFrameNavigator implements Navigator {
     return this.publication.positions;
   }
   goToPosition(position: number) {
-    if (oc(this.rights).autoGeneratePositions(true)) {
+    if ((this.rights?.autoGeneratePositions ?? true)) {
       let locator = this.publication.positions.filter(
         (el: Locator) => el.locations.position === position
       )[0];
@@ -2289,7 +2287,7 @@ export default class IFrameNavigator implements Navigator {
       return;
     }
 
-    if (oc(this.publication.metadata.rendition).layout("unknown") === "fixed") {
+    if ((this.publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
       var index = this.publication.getSpineIndex(this.currentChapterLink.href);
       var wrapper = HTMLUtilities.findRequiredElement(
         this.mainElement,
@@ -2383,7 +2381,7 @@ export default class IFrameNavigator implements Navigator {
 
     setTimeout(() => {
       if (this.view.layout !== "fixed") {
-        if (oc(this.view).isScrollMode()) {
+        if (this.view?.isScrollMode()) {
           this.view.setIframeHeight(this.iframe);
         }
       }
@@ -2394,11 +2392,11 @@ export default class IFrameNavigator implements Navigator {
       if (this.annotationModule !== undefined) {
         this.annotationModule.handleResize();
       } else {
-        if (oc(this.rights).enableSearch(false)) {
+        if (this.rights?.enableSearch) {
           this.searchModule.handleResize();
         }
       }
-      if (oc(this.rights).enableContentProtection(false)) {
+      if (this.rights?.enableContentProtection) {
         if (this.contentProtectionModule !== undefined) {
           this.contentProtectionModule.handleResize();
         }
@@ -2411,7 +2409,7 @@ export default class IFrameNavigator implements Navigator {
       if (this.chapterPosition) this.chapterPosition.innerHTML = "";
       if (this.remainingPositions) this.remainingPositions.innerHTML = "";
     } else {
-      if (oc(this.view).isPaginated()) {
+      if (this.view?.isPaginated()) {
         const locator = this.currentLocator();
         const currentPage = locator.displayInfo.resourceScreenIndex;
         const pageCount = locator.displayInfo.resourceScreenCount;
@@ -2535,7 +2533,7 @@ export default class IFrameNavigator implements Navigator {
 
   private hideView(_view: HTMLDivElement, _control: HTMLButtonElement): void {
     if (this.view.layout !== "fixed") {
-      if (oc(this.view).isScrollMode()) {
+      if (this.view?.isScrollMode()) {
         document.body.style.overflow = "auto";
       }
     }
@@ -2725,20 +2723,20 @@ export default class IFrameNavigator implements Navigator {
             this.currentChapterLink.href + "#" + this.newElementId;
         }
         setTimeout(async () => {
-          if (oc(this.rights).enableContentProtection(false)) {
+          if (this.rights?.enableContentProtection) {
             this.contentProtectionModule.initializeResource();
           }
         }, 200);
 
         setTimeout(async () => {
-          if (oc(this.rights).enableContentProtection(false)) {
+          if (this.rights?.enableContentProtection) {
             this.contentProtectionModule.recalculate(300);
           }
           if (this.annotationModule !== undefined) {
             this.annotationModule.drawHighlights();
             this.annotationModule.showHighlights();
           } else {
-            if (oc(this.rights).enableSearch(false)) {
+            if (this.rights?.enableSearch) {
               await this.highlighter.destroyAllhighlights(
                 this.iframe.contentDocument
               );

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -47,7 +47,6 @@ import AnnotationModule from "../modules/AnnotationModule";
 import TTSModule, { TTSSpeechConfig } from "../modules/TTS/TTSModule";
 import { goTo, IS_DEV } from "..";
 import Splitting from "../modules/TTS/splitting";
-import { oc } from "ts-optchain";
 import SearchModule from "../modules/search/SearchModule";
 import ContentProtectionModule from "../modules/protection/ContentProtectionModule";
 import TextHighlighter from "../modules/highlight/TextHighlighter";
@@ -707,7 +706,8 @@ export default class IFrameNavigator implements Navigator {
           }
           if (
             menuSearch &&
-            (this.view.delegate.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
+            (this.view.delegate.publication.metadata.rendition?.layout ??
+              "unknown") === "fixed"
           ) {
             menuSearch.parentElement.style.setProperty("display", "none");
           }
@@ -1875,7 +1875,9 @@ export default class IFrameNavigator implements Navigator {
         }
       }
     }
-    if ((this.publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
+    if (
+      (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
+    ) {
       setTimeout(() => {
         const height = getComputedStyle(
           index === 0 && this.iframe2
@@ -2188,7 +2190,7 @@ export default class IFrameNavigator implements Navigator {
     return this.publication.positions;
   }
   goToPosition(position: number) {
-    if ((this.rights?.autoGeneratePositions ?? true)) {
+    if (this.rights?.autoGeneratePositions ?? true) {
       let locator = this.publication.positions.filter(
         (el: Locator) => el.locations.position === position
       )[0];
@@ -2287,7 +2289,9 @@ export default class IFrameNavigator implements Navigator {
       return;
     }
 
-    if ((this.publication.metadata.rendition?.layout ?? "unknown") === "fixed") {
+    if (
+      (this.publication.metadata.rendition?.layout ?? "unknown") === "fixed"
+    ) {
       var index = this.publication.getSpineIndex(this.currentChapterLink.href);
       var wrapper = HTMLUtilities.findRequiredElement(
         this.mainElement,

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -26,7 +26,6 @@ import IFrameNavigator, {
   IFrameAttributes,
 } from "../navigator/IFrameNavigator";
 import { debounce } from "debounce";
-import { oc } from "ts-optchain";
 
 export default class ReflowableBookView implements BookView {
   layout = "reflowable";

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -103,7 +103,7 @@ export default class ReflowableBookView implements BookView {
       ) as any;
       html.style.setProperty("--USER__scroll", "readium-scroll-off");
     }
-    if (oc(this.delegate.rights).enableContentProtection(false)) {
+    if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.recalculate();
     }
   }
@@ -252,7 +252,7 @@ export default class ReflowableBookView implements BookView {
         element.style.height = originalHeight;
         this.setLeftColumnsWidth(roundedLeftWidth);
 
-        if (oc(this.delegate.rights).enableContentProtection(false)) {
+        if (this.delegate.rights?.enableContentProtection) {
           this.delegate.contentProtectionModule.recalculate(0);
         }
       }
@@ -291,7 +291,7 @@ export default class ReflowableBookView implements BookView {
         // Restore element's original height.
         element.style.height = originalHeight;
         this.setLeftColumnsWidth(roundedLeftWidth);
-        if (oc(this.delegate.rights).enableContentProtection(false)) {
+        if (this.delegate.rights?.enableContentProtection) {
           this.delegate.contentProtectionModule.recalculate(200);
         }
       }
@@ -347,7 +347,7 @@ export default class ReflowableBookView implements BookView {
       }
       this.delegate.checkResourcePosition();
     }
-    if (oc(this.delegate.rights).enableContentProtection(false)) {
+    if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.recalculate();
     }
   }
@@ -377,7 +377,7 @@ export default class ReflowableBookView implements BookView {
       }
       this.delegate.checkResourcePosition();
     }
-    if (oc(this.delegate.rights).enableContentProtection(false)) {
+    if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.recalculate();
     }
   }


### PR DESCRIPTION
This is a PR to remove the ts-optchain package, and refactor any code using it to instead rely on the regular typescript optional chaining and nullish coalescing. 

I did this using an automated codemod, and looked over the changes after. I will do a full review on this PR and I think we should at least do some testing as there is a chance that the codemod messed up some edge cases, though I tried to handle them.

We could either merge this now before testing is finished on the eslint-prettier branch or wait until it is merged to develop and merge it in there after. Either way, putting this here so we can start reviewing it.