### PR TITLE
Text Splitter: Remove some instances where whitespace elements are in…

### DIFF
--- a/src/modules/TTS/splitting.js
+++ b/src/modules/TTS/splitting.js
@@ -275,9 +275,13 @@
           createElement(F, "whitespace", " ", preserveWhitespace)
         );
       } else {
-        allElements.push(
-          createElement(F, "whitespace", " ", preserveWhitespace)
-        );
+        // Don't create whitespace element where textNode is invalid
+        var isChildTextNodeInvalid = /table|thead|tbody|tfoot|tr/i.test(el.tagName);
+        if (!isChildTextNodeInvalid) {
+          allElements.push(
+            createElement(F, "whitespace", " ", preserveWhitespace)
+          );
+        }
       }
     });
 


### PR DESCRIPTION
…valid

There is the potential for the whitespace placeholders ( `<span data-whitespace=""> </span>`) to be created in invalid places.

This deals with the case where the injected whitespace spans are being interpreted as columns or rows within tables by screen readers.

Not trying to test or limit all the invalid locations a `<span>` can be a child element.  That list would need to be cobbled together from potential list of permitted parents, and those list seem to be incomplete to me.  More info here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span - links can be found in the Permitted parents table entry.