### PR TITLE
Make currentSettings not async

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ export async function applyUserSettings(userSettings) {
   }
   R2Settings.applyUserSettings(userSettings);
 }
-export async function currentSettings() {
+export function currentSettings() {
   if (IS_DEV) {
     console.log("currentSettings");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ export function currentSettings() {
   if (IS_DEV) {
     console.log("currentSettings");
   }
-  return R2Settings.currentSettings();
+  return R2Settings.currentSettings;
 }
 export async function increase(incremental) {
   if (

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -1134,7 +1134,7 @@ export class UserSettings implements IUserSettings {
     this.settingsChangeCallback();
   }
 
-  async currentSettings() {
+  currentSettings() {
     return {
       appearance:
         UserSettings.appearanceValues[

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -1134,7 +1134,7 @@ export class UserSettings implements IUserSettings {
     this.settingsChangeCallback();
   }
 
-  currentSettings() {
+  get currentSettings() {
     return {
       appearance:
         UserSettings.appearanceValues[


### PR DESCRIPTION
This simply removes the `async` keyword from the `currentSettings` function, and the subsequent file in `UserSettings`. The keyword added an unnecessary promise wrapper to the function response which made reading the settings for display in a react app somewhat complicated. 

I also made `R2Settings.currentSettings` a getter, so it can now be accessed as a static property instead of as a function.

Consumers will need to update their code to no longer expect a promise here.