### PR TITLE
Removes duplicate export assignment for the load function in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -673,9 +673,6 @@ export async function load(config: ReaderConfig): Promise<any> {
   }
 }
 
-exports.load = async function (config: ReaderConfig) {
-  load(config);
-};
 exports.unload = async function () {
   unload();
 };


### PR DESCRIPTION
The function assigned to `exports.load` overwrites the first export of `load()`.

This second export des not return the Promise from `load()`. This causes the Promise from `D2Reader.load()` to resolve before it has actually completed. The return value of the second export of load is `Promise<void>` because it is an `async` function with an `undefined` return value.

It looks like all the functions in index.ts are exported twice, which should not be necessary. In this PR I only removed the `exports.load` one because as far as I can tell it is the only one that is causing an actual bug. 

I tested this change by removing `dist`, running `npm run build`, `npm start` and then viewing the example app in at localhost:8080.

The duplicate export of `load()` didn't cause any problems in the example app. We are importing D2Reader in a react app, and that's where we encountered the issue. 