### PR TITLE
Typescript argument fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,7 +380,7 @@ export default class D2Reader {
   resetUserSettings = async () => {
     return await this.settings.resetUserSettings();
   };
-  applyUserSettings = async (userSettings: UserSettings) => {
+  applyUserSettings = async (userSettings: Partial<UserSettings>) => {
     return await this.settings.applyUserSettings(userSettings);
   };
   get currentSettings() {

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -939,7 +939,7 @@ export class UserSettings implements IUserSettings {
     };
   }
 
-  async applyUserSettings(userSettings: UserSettings): Promise<void> {
+  async applyUserSettings(userSettings: Partial<UserSettings>): Promise<void> {
     if (userSettings.appearance) {
       let a: string;
       if (


### PR DESCRIPTION
This is a simple fix for the issue of the `applyUserSettings` argument requiring a full `UserSettings` object when in fact it should only need a `Partial<UserSettings>`