### PR TITLE
bugfix/settings.userProperties initialization

### DIFF
--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -176,6 +176,9 @@ export class UserSettings implements IUserSettings {
     await settings.initialise();
 
     if (config.initialUserSettings) {
+      if (!settings.userProperties) {
+        settings.userProperties = settings.getUserSettings();
+      }
       let initialUserSettings = config.initialUserSettings;
       if (initialUserSettings.verticalScroll !== undefined) {
         settings.verticalScroll = this.parseScrollSetting(


### PR DESCRIPTION
If you add initial user settings to ReaderConfig.userSettings in index_dita.html, you will see an error that reads `cannot read property getByRef of undefined`. It looks like the `userProperties` field on `settings` just needs to be initialized. 

![error_getByRef](https://user-images.githubusercontent.com/21145027/124981025-15312c80-e003-11eb-85b9-8c119abd95e7.png)
