### PR TITLE
Bugfix/loading injectables

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -806,7 +806,7 @@ export default class IFrameNavigator implements Navigator {
       // or we weren't able to insert the template in the element.
       console.error(err);
       this.abortOnError();
-      return new Promise<void>((_, reject) => reject(err)).catch(() => {});
+      return new Promise<void>((_, reject) => reject(err)).catch(() => { });
     }
   }
 
@@ -1006,7 +1006,7 @@ export default class IFrameNavigator implements Navigator {
           this.view.height =
             BrowserUtilities.getHeight() - 40 - this.attributes.margin;
           if (this.infoBottom) this.infoBottom.style.removeProperty("display");
-          document.body.onscroll = () => {};
+          document.body.onscroll = () => { };
           if (this.nextChapterBottomAnchorElement)
             this.nextChapterBottomAnchorElement.style.display = "none";
           if (this.previousChapterTopAnchorElement)
@@ -1408,7 +1408,7 @@ export default class IFrameNavigator implements Navigator {
     } catch (err) {
       console.error(err);
       this.abortOnError();
-      return new Promise<void>((_, reject) => reject(err)).catch(() => {});
+      return new Promise<void>((_, reject) => reject(err)).catch(() => { });
     }
   }
 
@@ -1534,64 +1534,13 @@ export default class IFrameNavigator implements Navigator {
           this.chapterTitle.innerHTML = "(Current Chapter)";
       }
 
+      await this.injectInjectablesIntoIframeHead();
+
       if (this.annotator) {
         await this.saveCurrentReadingPosition();
       }
       this.hideLoadingMessage();
       this.showIframeContents();
-
-      // Inject Readium CSS into Iframe Head
-
-      for (const iframe of this.iframes) {
-        const head = iframe.contentDocument.head;
-        if (head) {
-          head.insertBefore(
-            IFrameNavigator.createBase(this.currentChapterLink.href),
-            head.firstChild
-          );
-
-          this.injectables.forEach((injectable) => {
-            if (injectable.type === "style") {
-              if (injectable.fontFamily) {
-                // UserSettings.fontFamilyValues.push(injectable.fontFamily)
-                // this.settings.setupEvents()
-                // this.settings.addFont(injectable.fontFamily);
-                this.settings.initAddedFont();
-                if (!injectable.systemFont) {
-                  head.appendChild(
-                    IFrameNavigator.createCssLink(injectable.url)
-                  );
-                }
-              } else if (injectable.r2before) {
-                head.insertBefore(
-                  IFrameNavigator.createCssLink(injectable.url),
-                  head.firstChild
-                );
-              } else if (injectable.r2default) {
-                head.insertBefore(
-                  IFrameNavigator.createCssLink(injectable.url),
-                  head.childNodes[1]
-                );
-              } else if (injectable.r2after) {
-                if (injectable.appearance) {
-                  // this.settings.addAppearance(injectable.appearance);
-                  this.settings.initAddedAppearance();
-                }
-                head.appendChild(IFrameNavigator.createCssLink(injectable.url));
-              } else {
-                head.appendChild(IFrameNavigator.createCssLink(injectable.url));
-              }
-            } else if (injectable.type === "script") {
-              head.appendChild(
-                IFrameNavigator.createJavascriptLink(
-                  injectable.url,
-                  injectable.async
-                )
-              );
-            }
-          });
-        }
-      }
 
       if (this.highlighter !== undefined) {
         await this.highlighter.initialize();
@@ -1673,8 +1622,91 @@ export default class IFrameNavigator implements Navigator {
     } catch (err) {
       console.error(err);
       this.abortOnError();
-      return new Promise<void>((_, reject) => reject(err)).catch(() => {});
+      return new Promise<void>((_, reject) => reject(err)).catch(() => { });
     }
+  }
+
+  private async injectInjectablesIntoIframeHead(): Promise<void> {
+    // Inject Readium CSS into Iframe Head
+    const injectablesToLoad: Promise<boolean>[] = [];
+
+    const addLoadingInjectable = (
+      injectable: HTMLLinkElement | HTMLScriptElement
+    ) => {
+      const loadPromise = new Promise<boolean>((resolve) => {
+        injectable.onload = () => {
+          console.log("Injectable loaded...");
+          resolve(true);
+        };
+      });
+      injectablesToLoad.push(loadPromise);
+    };
+
+    for (const iframe of this.iframes) {
+      const head = iframe.contentDocument.head;
+      if (head) {
+        head.insertBefore(
+          IFrameNavigator.createBase(this.currentChapterLink.href),
+          head.firstChild
+        );
+
+        this.injectables.forEach((injectable) => {
+          if (injectable.type === "style") {
+            if (injectable.fontFamily) {
+              // UserSettings.fontFamilyValues.push(injectable.fontFamily)
+              // this.settings.setupEvents()
+              // this.settings.addFont(injectable.fontFamily);
+              this.settings.initAddedFont();
+              if (!injectable.systemFont) {
+                const link = IFrameNavigator.createCssLink(injectable.url);
+                head.appendChild(link);
+                addLoadingInjectable(link);
+              }
+            } else if (injectable.r2before) {
+              const link = IFrameNavigator.createCssLink(injectable.url);
+              head.insertBefore(
+                link,
+                head.firstChild
+              );
+              addLoadingInjectable(link);
+            } else if (injectable.r2default) {
+              const link = IFrameNavigator.createCssLink(injectable.url);
+              head.insertBefore(
+                link,
+                head.childNodes[1]
+              );
+              addLoadingInjectable(link);
+            } else if (injectable.r2after) {
+              if (injectable.appearance) {
+                // this.settings.addAppearance(injectable.appearance);
+                this.settings.initAddedAppearance();
+              }
+              const link = IFrameNavigator.createCssLink(injectable.url);
+              head.appendChild(link);
+              addLoadingInjectable(link);
+            } else {
+              const link = IFrameNavigator.createCssLink(injectable.url);
+              head.appendChild(link);
+              addLoadingInjectable(link);
+            }
+          } else if (injectable.type === "script") {
+            const script = IFrameNavigator.createJavascriptLink(
+              injectable.url,
+              injectable.async
+            );
+            head.appendChild(script);
+            addLoadingInjectable(script);
+          }
+        });
+      }
+    }
+
+    if (injectablesToLoad.length === 0) {
+      return;
+    }
+
+    await Promise.all(injectablesToLoad);
+    console.log("DONE!")
   }
 
   private abortOnError() {
@@ -1828,7 +1860,7 @@ export default class IFrameNavigator implements Navigator {
             if (
               this.iframes.length == 2 &&
               (this.publication.Metadata.Rendition?.Layout ?? "unknown") ===
-                "fixed"
+              "fixed"
             ) {
               this.currentSpreadLinks.right = {
                 href: this.currentChapterLink.href,
@@ -2151,7 +2183,7 @@ export default class IFrameNavigator implements Navigator {
         if (
           openIcon &&
           (openIcon.getAttribute("class") || "").indexOf(" inactive-icon") ===
-            -1
+          -1
         ) {
           const newIconClass =
             (openIcon.getAttribute("class") || "") + " inactive-icon";
@@ -2205,7 +2237,7 @@ export default class IFrameNavigator implements Navigator {
         if (
           closeIcon &&
           (closeIcon.getAttribute("class") || "").indexOf(" inactive-icon") ===
-            -1
+          -1
         ) {
           const newIconClass =
             (closeIcon.getAttribute("class") || "") + " inactive-icon";

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1635,7 +1635,6 @@ export default class IFrameNavigator implements Navigator {
     ) => {
       const loadPromise = new Promise<boolean>((resolve) => {
         injectable.onload = () => {
-          console.log("Injectable loaded...");
           resolve(true);
         };
       });
@@ -1706,7 +1705,6 @@ export default class IFrameNavigator implements Navigator {
     }
 
     await Promise.all(injectablesToLoad);
-    console.log("DONE!")
   }
 
   private abortOnError() {


### PR DESCRIPTION
The commit from my `getContentBytesLength` PR is also in this PR. I merged it into this branch because I modified the same file in both branches and didn't want to deal with any potential merge conflicts. 

There is a race condition between loading all the injectables and rendering the Iframe document content. For example, it's possible to see the content before all the stylesheets have been loaded. 

The fix for this issue is to assign the resolution of a Promise to the `HtmlLinkElement.onload` or `HtmlScriptElement.onload` callback function (both these element types provide an `onload` callback that fires when their content has finished loading and they're ready...), and then push that Promise to an array. Then use Promise.all to ensure all the injectables are loaded.

