### PR TITLE
Wrap createOrderedRange in try/catch

### DIFF
--- a/src/modules/highlight/renderer/iframe/selection.ts
+++ b/src/modules/highlight/renderer/iframe/selection.ts
@@ -135,33 +135,38 @@ export function createOrderedRange(
   endNode: Node,
   endOffset: number
 ): Range | undefined {
-  const range = new Range(); // document.createRange()
-  range.setStart(startNode, startOffset);
-  range.setEnd(endNode, endOffset);
-  if (!range.collapsed) {
-    if (IS_DEV) {
-      console.log(">>> createOrderedRange RANGE OK");
+  try {
+    const range = new Range(); // document.createRange()
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    if (!range.collapsed) {
+      if (IS_DEV) {
+        console.log(">>> createOrderedRange RANGE OK");
+      }
+      return range;
     }
-    return range;
-  }
 
-  if (IS_DEV) {
-    console.log(">>> createOrderedRange COLLAPSED ... RANGE REVERSE?");
-  }
-  const rangeReverse = new Range(); // document.createRange()
-  rangeReverse.setStart(endNode, endOffset);
-  rangeReverse.setEnd(startNode, startOffset);
-  if (!rangeReverse.collapsed) {
     if (IS_DEV) {
-      console.log(">>> createOrderedRange RANGE REVERSE OK.");
+      console.log(">>> createOrderedRange COLLAPSED ... RANGE REVERSE?");
     }
-    return range;
-  }
+    const rangeReverse = new Range(); // document.createRange()
+    rangeReverse.setStart(endNode, endOffset);
+    rangeReverse.setEnd(startNode, startOffset);
+    if (!rangeReverse.collapsed) {
+      if (IS_DEV) {
+        console.log(">>> createOrderedRange RANGE REVERSE OK.");
+      }
+      return range;
+    }
 
-  if (IS_DEV) {
-    console.log(">>> createOrderedRange RANGE REVERSE ALSO COLLAPSED?!");
+    if (IS_DEV) {
+      console.log(">>> createOrderedRange RANGE REVERSE ALSO COLLAPSED?!");
+    }
+    return undefined;
+  } catch (err) {
+    console.warn(err.message);
+    return undefined;
   }
-  return undefined;
 }
 
 export function convertRange(


### PR DESCRIPTION
After navigating to a chapter with one or more highlights I've made, I've been occasionally seeing this uncaught exception in the console: 

![unhandled-createrangeerror](https://user-images.githubusercontent.com/21145027/124986246-680de280-e009-11eb-91e7-d10a397ad3d0.png)

This error occurs in selection.ts -> `createOrderedRange`, which is called at some point in `AnnotationModule.drawHighlights()`. When switching to a new chapter `drawHighlights` seems to be called 3 times. The first time it's called, the error above sometimes appears. I couldn't figure out what was causing this error exactly, but I did notice that, even if the error occurred, it did not have an impact on the UI or the appearance of the highlights. So I temporarily fixed this by simply catching the exception, so that at least there weren't any unhandled exceptions. I still have the code logging the issue to the console when it occurs for further investigation if someone wants to look into it.  

![treat-as-warnings](https://user-images.githubusercontent.com/21145027/124987007-52e58380-e00a-11eb-93b8-d7009d3c6930.png)
  