### PR TITLE
bugfix/focusin on window.document

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1570,7 +1570,7 @@ export default class IFrameNavigator implements Navigator {
             this.keyboardEventHandler.setupEvents(iframe.contentDocument);
           }
           this.keyboardEventHandler.delegate = this;
-          this.keyboardEventHandler.setupEvents(document);
+          this.keyboardEventHandler.keydown(document);
         }
         if (this.view.layout !== "fixed") {
           if (this.view?.isScrollMode()) {

--- a/src/utils/KeyboardEventHandler.ts
+++ b/src/utils/KeyboardEventHandler.ts
@@ -26,8 +26,12 @@ export default class KeyboardEventHandler {
   public onForwardSwipe: (event: UIEvent) => void = () => {};
 
   public setupEvents = (element: HTMLElement | Document): void => {
-    var self = this;
+    this.focusin(element);
+    this.keydown(element);
+  };
 
+  public focusin = (element: HTMLElement | Document): void => {
+    const self = this;
     element.addEventListener(
       "focusin",
       function (event: KeyboardEvent) {
@@ -35,7 +39,10 @@ export default class KeyboardEventHandler {
       },
       true
     );
+  };
 
+  public keydown = (element: HTMLElement | Document): void => {
+    const self = this;
     element.addEventListener(
       "keydown",
       function (event: KeyboardEvent) {


### PR DESCRIPTION
Remove the "focusin" event listener on the `window.document` as it shouldn't be necessary. 