### PR TITLE
Feature: Sample-Read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.9.0",
+  "version": "1.10.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.9.0",
+      "version": "1.10.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-alpha.1",
+  "version": "1.10.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-alpha.1",
+      "version": "1.10.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-alpha.4",
+  "version": "1.10.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-alpha.4",
+      "version": "1.10.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.10",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-beta.10",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-alpha.4",
+  "version": "1.10.0-beta.1",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.9",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-beta.10",
+  "version": "1.10.0",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.10.0-alpha.1",
+  "version": "1.10.0-alpha.4",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "1.9.0",
+  "version": "1.10.0-alpha.1",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -594,6 +594,7 @@ export async function load(config: ReaderConfig): Promise<any> {
   const manifestJSON = await response.json();
   let publication = TaJsonDeserialize<Publication>(manifestJSON, Publication);
   publication.manifestUrl = webpubManifestUrl;
+  publication.sample = config.sample;
 
   if ((publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed") {
     config.rights.enableAnnotations = false;
@@ -738,6 +739,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     api: config.api,
     rights: config.rights,
     tts: config.tts,
+    sample: config.sample,
     injectables:
       (publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"
         ? config.injectablesFixed

--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -34,7 +34,7 @@ export class Publication extends R2Publication {
     return this.Spine;
   }
   get tableOfContents() {
-    if (this.sample?.isSampleRead) {
+    if (this.sample?.isSampleRead && this.positions?.length > 0) {
       return this.limitedTOC();
     }
     return this.TOC;
@@ -54,7 +54,7 @@ export class Publication extends R2Publication {
     let toc = this.TOC.map((item) => {
       if (item.Href) {
         const positions = this.positionsByHref(this.getRelativeHref(item.Href));
-        if (positions.length > 0) {
+        if (positions?.length > 0) {
           const locator = positions[0];
           let progress = Math.round(locator.locations.totalProgression * 100);
           let valid = progress <= this.sample?.limit;
@@ -202,7 +202,7 @@ export class Publication extends R2Publication {
    */
   public positionsByHref(href: string) {
     const decodedHref = decodeURI(href) ?? "";
-    return this.positions.filter((p: Locator) => decodedHref.includes(p.href));
+    return this.positions?.filter((p: Locator) => decodedHref.includes(p.href));
   }
 
   get hasMediaOverlays(): boolean {

--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -54,13 +54,15 @@ export class Publication extends R2Publication {
     let toc = this.TOC.map((item) => {
       if (item.Href) {
         const positions = this.positionsByHref(this.getRelativeHref(item.Href));
-        const locator = positions[0];
-        let progress = Math.round(locator.locations.totalProgression * 100);
-        let valid = progress <= this.sample.limit;
-        if (!valid) {
-          item.Href = undefined;
-          if (item.Children) {
-            disableChildren(item);
+        if (positions.length > 0) {
+          const locator = positions[0];
+          let progress = Math.round(locator.locations.totalProgression * 100);
+          let valid = progress <= this.sample.limit;
+          if (!valid) {
+            item.Href = undefined;
+            if (item.Children) {
+              disableChildren(item);
+            }
           }
         }
       }

--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -34,7 +34,7 @@ export class Publication extends R2Publication {
     return this.Spine;
   }
   get tableOfContents() {
-    if (this.sample.isSampleRead) {
+    if (this.sample?.isSampleRead) {
       return this.limitedTOC();
     }
     return this.TOC;
@@ -57,7 +57,7 @@ export class Publication extends R2Publication {
         if (positions.length > 0) {
           const locator = positions[0];
           let progress = Math.round(locator.locations.totalProgression * 100);
-          let valid = progress <= this.sample.limit;
+          let valid = progress <= this.sample?.limit;
           if (!valid) {
             item.Href = undefined;
             if (item.Children) {

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -71,6 +71,10 @@ export default class MediaOverlayModule implements ReaderModule {
     document,
     "#menu-button-pause"
   ) as HTMLLinkElement;
+  private menu: HTMLLinkElement = HTMLUtilities.findElement(
+    document,
+    "#menu-button-mediaoverlay"
+  ) as HTMLLinkElement;
 
   private currentAudioBegin: number | undefined;
   private currentAudioEnd: number | undefined;
@@ -111,6 +115,12 @@ export default class MediaOverlayModule implements ReaderModule {
   protected async start(): Promise<void> {
     this.delegate.mediaOverlayModule = this;
     if (IS_DEV) console.log("MediaOverlay module start");
+
+    if (!this.delegate.hasMediaOverlays) {
+      this.play.parentElement.style.setProperty("display", "none");
+      this.pause.parentElement.style.setProperty("display", "none");
+      this.menu.parentElement.style.setProperty("display", "none");
+    }
   }
 
   async initialize() {

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -71,10 +71,6 @@ export default class MediaOverlayModule implements ReaderModule {
     document,
     "#menu-button-pause"
   ) as HTMLLinkElement;
-  private menu: HTMLLinkElement = HTMLUtilities.findElement(
-    document,
-    "#menu-button-mediaoverlay"
-  ) as HTMLLinkElement;
 
   private currentAudioBegin: number | undefined;
   private currentAudioEnd: number | undefined;
@@ -115,12 +111,6 @@ export default class MediaOverlayModule implements ReaderModule {
   protected async start(): Promise<void> {
     this.delegate.mediaOverlayModule = this;
     if (IS_DEV) console.log("MediaOverlay module start");
-
-    if (!this.delegate.hasMediaOverlays) {
-      this.play.parentElement.style.setProperty("display", "none");
-      this.pause.parentElement.style.setProperty("display", "none");
-      this.menu.parentElement.style.setProperty("display", "none");
-    }
   }
 
   async initialize() {

--- a/src/modules/sampleread/SampleReadEventHandler.ts
+++ b/src/modules/sampleread/SampleReadEventHandler.ts
@@ -57,9 +57,6 @@ export default class SampleReadEventHandler {
     }
 
     function preventDefaultForScrollKeys(e) {
-      console.log(e.keyCode);
-      console.log(keys[e.keyCode]);
-      console.log(valid);
       if (keys[e.keyCode] && !valid) {
         preventDefault(e);
       }
@@ -133,7 +130,6 @@ export default class SampleReadEventHandler {
     }
 
     // IE9, Chrome, Safari, Opera
-    console.log("add sample event handlers");
     window.addEventListener("mousewheel", MouseWheelHandler, wheelOpt);
     // Firefox
     window.addEventListener("DOMMouseScroll", MouseWheelHandler, wheelOpt);

--- a/src/modules/sampleread/SampleReadEventHandler.ts
+++ b/src/modules/sampleread/SampleReadEventHandler.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018-2021 DITA (AM Consulting LLC)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Developed on behalf of: Bibliotheca LLC
+ * Licensed to: Bibliotheca LLC under one or more contributor license agreements.
+ */
+
+import { debounce } from "debounce";
+import IFrameNavigator from "../../navigator/IFrameNavigator";
+
+export default class SampleReadEventHandler {
+  delegate: IFrameNavigator;
+  constructor(delegate: IFrameNavigator) {
+    this.delegate = delegate;
+  }
+
+  enforceSampleRead = debounce((position) => {
+    let progress = Math.round(position.locations.totalProgression * 100);
+    let valid = progress <= this.delegate.sample?.limit;
+    if (this.delegate.view.layout === "fixed") {
+      if (
+        !valid &&
+        position.locations.position <= this.delegate.sample?.minimum
+      ) {
+        valid = true;
+      }
+    }
+
+    // left: 37, up: 38, right: 39, down: 40,
+    // spacebar: 32, pageup: 33, pagedown: 34, end: 35, home: 36
+    let keys = {
+      37: 1,
+      38: 0,
+      39: 1,
+      40: 1,
+      32: 1,
+      33: 1,
+      34: 1,
+      35: 1,
+      36: 1,
+    };
+
+    function preventDefault(e) {
+      e.preventDefault();
+    }
+
+    function preventDefaultForScrollKeys(e) {
+      console.log(e.keyCode);
+      console.log(keys[e.keyCode]);
+      console.log(valid);
+      if (keys[e.keyCode] && !valid) {
+        preventDefault(e);
+      }
+    }
+
+    // modern Chrome requires { passive: false } when adding event
+    let supportsPassive = false;
+    try {
+      window.addEventListener(
+        "test",
+        null,
+        Object.defineProperty({}, "passive", {
+          get: function () {
+            supportsPassive = true;
+          },
+        })
+      );
+    } catch (e) {}
+
+    let wheelOpt = supportsPassive ? { passive: false } : false;
+    // let wheelEvent =
+    //   "onwheel" in document.createElement("div") ? "wheel" : "mousewheel";
+
+    function MouseWheelHandler(e) {
+      // cross-browser wheel delta
+      e = e || window.event; // old IE support
+      let delta = Math.max(-1, Math.min(1, e.wheelDelta || -e.detail));
+
+      if (delta == 1) {
+        // move up
+      }
+      if (delta == -1 && !valid) {
+        // move down
+        e.preventDefault();
+        // e.stopPropagation();
+        return false;
+      }
+      return false;
+    }
+
+    let lastY;
+
+    function TouchMoveHandler(e) {
+      e = e || window.event;
+      let target = e.target || e.srcElement;
+
+      let currentY = e.touches[0].clientY;
+      if (currentY > lastY) {
+        // move up
+      } else if (currentY < lastY && !valid) {
+        // move down
+        if (!target.className.match(/\baltNav\b/)) {
+          e.returnValue = false;
+          if (e.cancelable) {
+            e.cancelBubble = true;
+          }
+          if (e.preventDefault && e.cancelable) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }
+        return false;
+      }
+      lastY = currentY;
+      return false;
+    }
+    function TouchStartHandler(e) {
+      e = e || window.event;
+      lastY = e.touches[0].clientY;
+      return false;
+    }
+
+    // IE9, Chrome, Safari, Opera
+    console.log("add sample event handlers");
+    window.addEventListener("mousewheel", MouseWheelHandler, wheelOpt);
+    // Firefox
+    window.addEventListener("DOMMouseScroll", MouseWheelHandler, wheelOpt);
+    // window.addEventListener(wheelEvent, preventDefault, wheelOpt); // modern desktop
+    window.addEventListener("keydown", preventDefaultForScrollKeys, wheelOpt);
+    window.addEventListener("touchmove", TouchMoveHandler, wheelOpt);
+    window.addEventListener("touchstart", TouchStartHandler, wheelOpt);
+
+    if (!valid) {
+      this.delegate.iframes[0].blur();
+      if (this.delegate.errorMessage) {
+        this.delegate.errorMessage.style.display = "block";
+        this.delegate.errorMessage.style.backgroundColor = "rgb(255, 255, 255)";
+        this.delegate.errorMessage.innerHTML = this.delegate.sample?.popup;
+      }
+    } else {
+      this.delegate.iframes[0].focus();
+      if (this.delegate.errorMessage) {
+        this.delegate.errorMessage.style.display = "none";
+        this.delegate.errorMessage.style.removeProperty("background-color");
+      }
+    }
+  }, 300);
+}

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2519,7 +2519,7 @@ export default class IFrameNavigator implements Navigator {
 
   private handleNextPageClick(event: MouseEvent | TouchEvent | KeyboardEvent) {
     let valid = true;
-    if (this.sample?.isSampleRead) {
+    if (this.sample?.isSampleRead && this.publication.positions) {
       const locator = this.currentLocator();
       let progress = Math.round(locator.locations.totalProgression * 100);
       valid = progress <= this.sample?.limit;
@@ -2530,7 +2530,11 @@ export default class IFrameNavigator implements Navigator {
       }
     }
 
-    if ((valid && this.sample?.isSampleRead) || !this.sample?.isSampleRead) {
+    if (
+      (valid && this.sample?.isSampleRead && this.publication.positions) ||
+      !this.sample?.isSampleRead ||
+      !this.publication.positions
+    ) {
       this.stopReadAloud(true);
       if (this.view.layout === "fixed") {
         this.handleNextChapterClick(event);
@@ -2548,7 +2552,7 @@ export default class IFrameNavigator implements Navigator {
         }
       }
     }
-    if (!valid && this.sample?.isSampleRead) {
+    if (!valid && this.sample?.isSampleRead && this.publication.positions) {
       if (event) {
         event.preventDefault();
         event.stopPropagation();

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -3111,7 +3111,10 @@ export default class IFrameNavigator implements Navigator {
 
         this.precessContentForIframe();
 
-        if (this.rights?.enableContentProtection) {
+        if (
+          this.rights?.enableContentProtection &&
+          this.contentProtectionModule !== undefined
+        ) {
           await this.contentProtectionModule.initializeResource();
         }
 
@@ -3121,7 +3124,10 @@ export default class IFrameNavigator implements Navigator {
         ) {
           await this.mediaOverlayModule.initializeResource(this.currentLink());
         }
-        if (this.rights?.enableContentProtection) {
+        if (
+          this.rights?.enableContentProtection &&
+          this.contentProtectionModule !== undefined
+        ) {
           this.contentProtectionModule.recalculate(300);
         }
         if (this.annotationModule !== undefined) {

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -95,6 +95,7 @@ export interface IFrameAttributes {
   navHeight?: number;
   iframePaddingTop?: number;
   bottomInfoHeight?: number;
+  sideNavPosition?: "left" | "right";
 }
 export interface IFrameNavigatorConfig {
   mainElement: HTMLElement;
@@ -723,7 +724,7 @@ export default class IFrameNavigator implements Navigator {
         let elements = document.querySelectorAll(".sidenav");
         if (elements) {
           self.mSidenav = Sidenav.init(elements, {
-            edge: "left",
+            edge: this.attributes?.sideNavPosition ?? "left",
           });
         }
         let collapsible = document.querySelectorAll(".collapsible");

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -3383,12 +3383,14 @@ export default class IFrameNavigator implements Navigator {
       this.iframes[0].blur();
       if (this.errorMessage) {
         this.errorMessage.style.display = "block";
+        this.errorMessage.style.backgroundColor = "rgb(255, 255, 255)";
         this.errorMessage.innerHTML = this.sample.popup;
       }
     } else {
       this.iframes[0].focus();
       if (this.errorMessage) {
         this.errorMessage.style.display = "none";
+        this.errorMessage.style.removeProperty("background-color");
       }
     }
   }, 300);

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -347,12 +347,12 @@ export default class IFrameNavigator implements Navigator {
     removeEventListenerOptional(
       this.previousChapterAnchorElement,
       "click",
-      this.handlePreviousChapterClick.bind(this)
+      this.handlePreviousPageClick.bind(this)
     );
     removeEventListenerOptional(
       this.nextChapterAnchorElement,
       "click",
-      this.handleNextChapterClick.bind(this)
+      this.handleNextPageClick.bind(this)
     );
 
     removeEventListenerOptional(
@@ -2545,6 +2545,12 @@ export default class IFrameNavigator implements Navigator {
           event.preventDefault();
           event.stopPropagation();
         }
+      }
+    }
+    if (!valid && this.sample.isSampleRead) {
+      if (event) {
+        event.preventDefault();
+        event.stopPropagation();
       }
     }
   }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -857,12 +857,12 @@ export default class IFrameNavigator implements Navigator {
     addEventListenerOptional(
       this.previousChapterAnchorElement,
       "click",
-      this.handlePreviousChapterClick.bind(this)
+      this.handlePreviousPageClick.bind(this)
     );
     addEventListenerOptional(
       this.nextChapterAnchorElement,
       "click",
-      this.handleNextChapterClick.bind(this)
+      this.handleNextPageClick.bind(this)
     );
 
     addEventListenerOptional(

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -105,9 +105,6 @@ export interface IFrameNavigatorConfig {
   publication: Publication;
   settings: UserSettings;
   annotator?: Annotator;
-  eventHandler?: EventHandler;
-  touchEventHandler?: TouchEventHandler;
-  keyboardEventHandler?: KeyboardEventHandler;
   upLink?: UpLinkConfig;
   initialLastReadingPosition?: ReadingPosition;
   rights?: ReaderRights;
@@ -278,9 +275,6 @@ export default class IFrameNavigator implements Navigator {
     const navigator = new this(
       config.settings,
       config.annotator || null,
-      config.eventHandler || null,
-      config.touchEventHandler || null,
-      config.keyboardEventHandler || null,
       config.upLink || null,
       config.initialLastReadingPosition || null,
       config.publication,
@@ -305,9 +299,6 @@ export default class IFrameNavigator implements Navigator {
   protected constructor(
     settings: UserSettings,
     annotator: Annotator | null = null,
-    eventHandler: EventHandler | null = null,
-    touchEventHandler: TouchEventHandler | null = null,
-    keyboardEventHandler: KeyboardEventHandler | null = null,
     upLinkConfig: UpLinkConfig | null = null,
     initialLastReadingPosition: ReadingPosition | null = null,
     publication: Publication,
@@ -318,18 +309,16 @@ export default class IFrameNavigator implements Navigator {
     injectables: Array<Injectable>,
     attributes: IFrameAttributes,
     services: PublicationServices,
-    sample: SampleRead,
-    sampleReadEventHandler: SampleReadEventHandler | null = null
+    sample: SampleRead
   ) {
     this.settings = settings;
     this.annotator = annotator;
     this.view = settings.view;
     this.view.attributes = attributes;
     this.view.delegate = this;
-    this.eventHandler = eventHandler || new EventHandler();
-    this.touchEventHandler = touchEventHandler || new TouchEventHandler();
-    this.keyboardEventHandler =
-      keyboardEventHandler || new KeyboardEventHandler();
+    this.eventHandler = new EventHandler();
+    this.touchEventHandler = new TouchEventHandler();
+    this.keyboardEventHandler = new KeyboardEventHandler();
     this.upLinkConfig = upLinkConfig;
     this.initialLastReadingPosition = initialLastReadingPosition;
     this.publication = publication;
@@ -341,8 +330,7 @@ export default class IFrameNavigator implements Navigator {
     this.attributes = attributes || { margin: 0 };
     this.services = services;
     this.sample = sample;
-    this.sampleReadEventHandler =
-      sampleReadEventHandler || new SampleReadEventHandler(this);
+    this.sampleReadEventHandler = new SampleReadEventHandler(this);
   }
 
   async stop() {

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -341,12 +341,12 @@ export default class IFrameNavigator implements Navigator {
     removeEventListenerOptional(
       this.previousChapterAnchorElement,
       "click",
-      this.handlePreviousPageClick.bind(this)
+      this.handlePreviousChapterClick.bind(this)
     );
     removeEventListenerOptional(
       this.nextChapterAnchorElement,
       "click",
-      this.handleNextPageClick.bind(this)
+      this.handleNextChapterClick.bind(this)
     );
 
     removeEventListenerOptional(
@@ -854,12 +854,12 @@ export default class IFrameNavigator implements Navigator {
     addEventListenerOptional(
       this.previousChapterAnchorElement,
       "click",
-      this.handlePreviousPageClick.bind(this)
+      this.handlePreviousChapterClick.bind(this)
     );
     addEventListenerOptional(
       this.nextChapterAnchorElement,
       "click",
-      this.handleNextPageClick.bind(this)
+      this.handleNextChapterClick.bind(this)
     );
 
     addEventListenerOptional(

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1734,6 +1734,7 @@ export default class IFrameNavigator implements Navigator {
     const self = this;
     var index = this.publication.getSpineIndex(this.currentChapterLink.href);
     var even: boolean = index % 2 === 1;
+    this.showLoadingMessageAfterDelay();
 
     function writeIframeDoc(content: string, href: string) {
       const parser = new DOMParser();

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -726,7 +726,21 @@ export default class IFrameNavigator implements Navigator {
           this.headerMenu,
           "#menu-button-bookmark"
         ) as HTMLLinkElement;
+
+        var play = HTMLUtilities.findElement(
+          this.headerMenu,
+          "#menu-button-play"
+        ) as HTMLLinkElement;
+        var pause = HTMLUtilities.findElement(
+          this.headerMenu,
+          "#menu-button-pause"
+        ) as HTMLLinkElement;
+        var menu = HTMLUtilities.findElement(
+          this.headerMenu,
+          "#menu-button-mediaoverlay"
+        ) as HTMLLinkElement;
       }
+
       if (this.rights?.enableMaterial) {
         let elements = document.querySelectorAll(".sidenav");
         if (elements) {
@@ -784,7 +798,7 @@ export default class IFrameNavigator implements Navigator {
           }
           if (!this.rights?.enableSearch) {
             if (menuSearch)
-              menuSearch.parentElement.style.removeProperty("display");
+              menuSearch.parentElement.style.setProperty("display", "none");
           }
           if (
             menuSearch &&
@@ -803,6 +817,16 @@ export default class IFrameNavigator implements Navigator {
           if (menuBookmark)
             menuBookmark.parentElement.style.setProperty("display", "none");
         }
+      }
+
+      if (this.hasMediaOverlays) {
+        if (play) play.parentElement.style.setProperty("display", "block");
+        if (pause) pause.parentElement.style.setProperty("display", "block");
+        if (menu) menu.parentElement.style.setProperty("display", "block");
+      } else {
+        if (play) play.parentElement.style.setProperty("display", "none");
+        if (pause) pause.parentElement.style.setProperty("display", "none");
+        if (menu) menu.parentElement.style.setProperty("display", "none");
       }
 
       return await this.loadManifest();

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2526,18 +2526,18 @@ export default class IFrameNavigator implements Navigator {
 
   private handleNextPageClick(event: MouseEvent | TouchEvent | KeyboardEvent) {
     let valid = true;
-    if (this.sample.isSampleRead) {
+    if (this.sample?.isSampleRead) {
       const locator = this.currentLocator();
       let progress = Math.round(locator.locations.totalProgression * 100);
-      valid = progress <= this.sample.limit;
+      valid = progress <= this.sample?.limit;
       if (this.view.layout === "fixed") {
-        if (!valid && locator.locations.position <= this.sample.minimum) {
+        if (!valid && locator.locations.position <= this.sample?.minimum) {
           valid = true;
         }
       }
     }
 
-    if ((valid && this.sample.isSampleRead) || !this.sample.isSampleRead) {
+    if ((valid && this.sample?.isSampleRead) || !this.sample?.isSampleRead) {
       this.stopReadAloud(true);
       if (this.view.layout === "fixed") {
         this.handleNextChapterClick(event);
@@ -2555,7 +2555,7 @@ export default class IFrameNavigator implements Navigator {
         }
       }
     }
-    if (!valid && this.sample.isSampleRead) {
+    if (!valid && this.sample?.isSampleRead) {
       if (event) {
         event.preventDefault();
         event.stopPropagation();
@@ -3268,9 +3268,9 @@ export default class IFrameNavigator implements Navigator {
 
   enforceSampleRead = debounce((position) => {
     let progress = Math.round(position.locations.totalProgression * 100);
-    let valid = progress <= this.sample.limit;
+    let valid = progress <= this.sample?.limit;
     if (this.view.layout === "fixed") {
-      if (!valid && position.locations.position <= this.sample.minimum) {
+      if (!valid && position.locations.position <= this.sample?.minimum) {
         valid = true;
       }
     }
@@ -3384,7 +3384,7 @@ export default class IFrameNavigator implements Navigator {
       if (this.errorMessage) {
         this.errorMessage.style.display = "block";
         this.errorMessage.style.backgroundColor = "rgb(255, 255, 255)";
-        this.errorMessage.innerHTML = this.sample.popup;
+        this.errorMessage.innerHTML = this.sample?.popup;
       }
     } else {
       this.iframes[0].focus();
@@ -3450,7 +3450,7 @@ export default class IFrameNavigator implements Navigator {
         };
       }
 
-      if (this.sample.isSampleRead) {
+      if (this.sample?.isSampleRead) {
         this.enforceSampleRead(position);
       }
 

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -3314,7 +3314,7 @@ export default class IFrameNavigator implements Navigator {
         };
       }
 
-      if (this.sample?.isSampleRead) {
+      if (this.sample?.isSampleRead && this.publication.positions) {
         this.sampleReadEventHandler?.enforceSampleRead(position);
       }
 

--- a/src/styles/sass/reader/_timeline.scss
+++ b/src/styles/sass/reader/_timeline.scss
@@ -16,9 +16,9 @@
  * Developed on behalf of: DITA
  * Licensed to: Bibliotheca LLC, Bokbasen AS and CAST under one or more contributor license agreements.
  */
- 
+
  @media only screen and (max-width: 600px) {
-    .timeline, .scrubber > input, #nav-mobile-left  > li > a[rel=next], #nav-mobile-left  > li > a[rel=prev] {
+    .timeline, .scrubber > input {
         display: none;
     }
 }

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -21,7 +21,7 @@
 <html lang="en">
 
 <head>
-    <title>D2 Reader</title>
+    <title>Dita Reader</title>
     <meta charset="utf-8" />
     <meta name="author" content="Aferdita Muriqi" />
     <meta name="description" content="A viewer application for EPUB files." />
@@ -69,7 +69,7 @@
                 </nav>
             </div>
             <ul id="sidenav-left" class="sidenav">
-                <li><a href="#" class="logo-container ">D2 Reader<i class="material-icons  left" style="margin-right: 15px">
+                <li><a href="#" class="logo-container ">Dita Reader<i class="material-icons  left" style="margin-right: 15px">
                             import_contacts
                         </i><i class="material-icons right  editAnnotations" id="expand-menu">unfold_more</i></a></li>
                 <li class="no-padding ">
@@ -595,6 +595,11 @@ height: 50px;
             //     positions: new URL("https://alice.dita.digital/positions.json"),
             //     weight: new URL("https://alice.dita.digital/weight.json"),
             // },
+            sample: {
+                isSampleRead: true,
+                limit: 10, // in percent e.g. 5%
+                popup: "You can borrow the book to continue reading."
+            },
             mediaOverlays: {
                 autoScroll: true,
                 autoTurn: true,

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -596,12 +596,12 @@ height: 50px;
             //     positions: new URL("https://alice.dita.digital/positions.json"),
             //     weight: new URL("https://alice.dita.digital/weight.json"),
             // },
-            sample: {
-                isSampleRead: true,
-                limit: 10, // in percent e.g. 5%
-                minimum: 5, // in pages
-                popup: "You can borrow the book to continue reading."
-            },
+            // sample: {
+            //     isSampleRead: true,
+            //     limit: 10, // in percent e.g. 5%
+            //     minimum: 5, // in pages
+            //     popup: "You can borrow the book to continue reading."
+            // },
             mediaOverlays: {
                 autoScroll: true,
                 autoTurn: true,

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -62,8 +62,8 @@
                         </ul>
                         <ul id="nav-mobile-left" class="left">
                             <li><a href="#!" data-target="sidenav-left" class="sidenav-trigger left"><i class="material-icons  show-on-large">menu</i></a></li>
-                            <li><a rel="prev" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons ">arrow_back_ios</i></a></li>
-                            <li><a rel="next" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons ">arrow_forward_ios</i></a></li>
+                            <li><a rel="prev" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_back_ios</i></a></li>
+                            <li><a rel="next" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_forward_ios</i></a></li>
                         </ul>
                     </div>
                 </nav>

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -578,7 +578,8 @@ height: 50px;
                 margin: 120,
                 navHeight: 70,
                 iframePaddingTop: 20,
-                bottomInfoHeight: 60
+                bottomInfoHeight: 60,
+                sideNavPosition: 'left'
             },
             rights: {
                 enableMaterial: true,

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -599,6 +599,7 @@ height: 50px;
             sample: {
                 isSampleRead: true,
                 limit: 10, // in percent e.g. 5%
+                minimum: 5, // in pages
                 popup: "You can borrow the book to continue reading."
             },
             mediaOverlays: {

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -51,8 +51,8 @@
                 <nav class="navbar">
                     <div class="nav-wrapper"><span class="brand-logo  hide-on-med-and-down " id="book-title"></span>
                         <ul id="nav-mobile-right" class="right">
-                            <li><a rel="prev" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_back_ios</i></a></li>
-                            <li><a rel="next" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_forward_ios</i></a></li>
+                            <li><a style="padding-left: 7px; padding-right: 7px;" onclick="javascript:D2Reader.previousPage()"><i class="material-icons show-on-large">arrow_back_ios</i></a></li>
+                            <li><a style="padding-left: 7px; padding-right: 7px;" onclick="javascript:D2Reader.nextPage()"><i class="material-icons show-on-large">arrow_forward_ios</i></a></li>
                             <li><a class="saveBookmark" id="menu-button-bookmark"><i class="material-icons">bookmark</i></a></li>
                             <li><a data-target="container-view-settings-custom" class="dropdown-trigger " id="menu-button-settings" onclick="reload()"><i class="material-icons">settings</i></a></li>
                             <li><a href="#!" data-target="sidenav-left" class="sidenav-trigger left"><i class="material-icons  show-on-large">menu</i></a></li>

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -1,0 +1,509 @@
+<!--
+ * Copyright 2018-2020 DITA (AM Consulting LLC)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Developed on behalf of: DITA
+ * Licensed to: Bokbasen AS and CAST under one or more contributor license agreements.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Dita Reader</title>
+    <meta charset="utf-8" />
+    <meta name="author" content="Aferdita Muriqi" />
+    <meta name="description" content="A viewer application for EPUB files." />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+
+    <!-- R2 Reader CSS -->
+    <link rel="stylesheet" href="reader.css" />
+
+    <script> var exports = {}; </script>
+    <script src="reader.js"></script>
+
+    <!-- Material Icons-->
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <!-- START Material CSS -->
+    <!-- Material header and footer CSS  - uncomment if  custom header an d footer is provided-->
+    <link rel="stylesheet" href="material.css" />
+    <!-- END Material CSS -->
+
+</head>
+
+<body>
+
+    <div class="content" id="root">
+        <header id="headerMenu">
+            <div class="navbar-fixed">
+                <nav class="navbar">
+                    <div class="nav-wrapper"><span class="brand-logo  hide-on-med-and-down " id="book-title"></span>
+                        <ul id="nav-mobile-right" class="right">
+                            <li><a rel="prev" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_back_ios</i></a></li>
+                            <li><a rel="next" style="padding-left: 7px; padding-right: 7px;"><i class="material-icons show-on-large">arrow_forward_ios</i></a></li>
+                            <li><a class="saveBookmark" id="menu-button-bookmark"><i class="material-icons">bookmark</i></a></li>
+                            <li><a data-target="container-view-settings-custom" class="dropdown-trigger " id="menu-button-settings" onclick="reload()"><i class="material-icons">settings</i></a></li>
+                            <li><a href="#!" data-target="sidenav-left" class="sidenav-trigger left"><i class="material-icons  show-on-large">menu</i></a></li>
+                        </ul>
+                        <ul id="nav-mobile-left" class="left">
+                        </ul>
+                    </div>
+                </nav>
+            </div>
+            <ul id="sidenav-left" class="sidenav">
+                <li><a href="#" class="logo-container ">Dita Reader<i class="material-icons  left" style="margin-right: 15px">
+                            import_contacts
+                        </i><i class="material-icons right  editAnnotations" id="expand-menu">unfold_more</i></a></li>
+                <li class="no-padding ">
+                    <ul class="collapsible collapsible-accordion">
+                        <li style="padding-left: 16px" id="sidenav-section-gotopage">
+                            Go To Page: <input type="text" style="width:100px;" id="goToPageNumberInput" /><button id="goToPageNumberButton">Go</button>
+                        </li>
+                        <li class="bold" id="sidenav-section-toc"><a class="collapsible-header ">Table of Contents<i class="material-icons chevron purple-yellow-text">chevron_left</i></a>
+                            <div id="container-view-toc" class="contents-view collapsible-body active" style="background-color : #ffffff">
+                            </div>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+            <div id="container-view-settings-custom" class="dropdown-content settings-view settings">
+                <div class="range-slider">
+                    <label style="display: block;
+    text-align: center;
+    line-height: 12pt;height: 0px;">Fontsize</label>
+                    <input class="range-slider__range_settings" type="range" min="100" max="300" step="25"
+                           value="100" id="fontSize" name="fontSize"
+                           onchange="D2Reader.applyUserSettings({ fontSize: this.value })"/>
+                </div>
+                <div>
+                    <label style="display: block;
+    text-align: center;
+    line-height: 12pt;height: 0px;">Font</label>
+                    <center>
+                        <select style="width: 80%;" onchange="D2Reader.applyUserSettings({fontFamily:value});reload();"
+                                id="fontFamily">
+                            <option value="Original">Publisher</option>
+                            <option value="serif">Serif</option>
+                            <option value="sans-serif">Sans-serif</option>
+                            <option value="opendyslexic">Open Dyslexic</option>
+                        </select>
+                    </center>
+                </div>
+                <div>
+                    <center>
+                        <button style="width: 30%;
+    background-color: white;
+    height: 50px;
+    border-radius: 25px 0px 0px 25px;
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: black;
+    font-size: 9pt;text-transform: uppercase" onclick="D2Reader.applyUserSettings({appearance:'day'})">DAY
+                        </button><button style="width: 30%;
+    background-color: wheat;
+    height: 50px;
+    /*border-radius: 25px;*/
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: black;
+    font-size: 9pt;text-transform: uppercase" onclick="D2Reader.applyUserSettings({appearance:'sepia'})">SEPIA
+                    </button><button style="width: 30%;
+    background-color: black;
+    height: 50px;
+    border-radius: 0px 25px 25px 0px;
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: white;
+    font-size: 9pt;text-transform: uppercase" onclick="D2Reader.applyUserSettings({appearance:'night'})">NIGHT
+                    </button>
+                    </center>
+                </div>
+                <div id="scrollMode" style="padding-bottom: 10px">
+                    <label style="display: block;
+                               text-align: center;
+                               line-height: 12pt;">Layout</label>
+                    <center>
+                        <button style="width: 100px;
+        background-color: white;
+height: 50px;
+    border-radius: 25px 0px 0px 25px;
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: black;
+    font-size: 9pt; text-transform: uppercase"
+                                onclick="D2Reader.applyUserSettings({verticalScroll:true});setScroll('true')">Scroll
+                        </button><button style="width: 100px;
+        background-color: white;
+height: 50px;
+    border-radius: 0px 25px 25px 0px;
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: black;
+    font-size: 9pt;text-transform: uppercase"
+                                         onclick="D2Reader.applyUserSettings({verticalScroll:false});setScroll('false')">
+                        Paginated
+                    </button>
+                    </center>
+                </div>
+                <div id="reset" style="padding-bottom: 10px">
+
+                    <center>
+                        <button style="width: 100px;
+        background-color: white;
+    height: 50px;
+    border-radius: 25px 25px 25px 25px;
+    border-color: #00000020;
+    border-width: 1px;
+    border-style: solid;
+    color: black;
+    font-size: 9pt; text-transform: uppercase"
+                                onclick="D2Reader.resetUserSettings();">Reset
+                        </button>
+                    </center>
+                </div>
+            </div>
+        </header>
+
+        <div id="D2Reader-Container" style="width: 100%; height: 100%; position: relative;">
+            <main style="overflow: hidden" tabindex=-1 id="iframe-wrapper">
+                <div id="reader-loading" class="loading"></div>
+                <div id="reader-error" class="error"></div>
+                <div id="reader-info-top" class="info top">
+                    <span class="book-title"></span>
+                </div>
+                <div id="reader-info-bottom" class="info bottom">
+                    <div style="display: flex;justify-content: center;">
+                        <span class="chapter-position"></span>&nbsp;
+                        <span class="chapter-title"></span>
+                    </div>
+                    <div class="scrubber">
+                        <input class="range-slider__range" style="width:100%" type="range" min="1" step="1" id="positionSlider" name="positionSlider" onchange="javascript:D2Reader.goToPosition( this.value )" />
+                    </div>
+                    <div>
+                        <span class="remaining-positions"></span>
+                    </div>
+                </div>
+            </main>
+            <div id="container-view-security" class="security"></div>
+            <div id="container-view-timeline" class="timeline" style="top: 5rem;bottom: 2.5rem;"></div>
+            <a id="previous-chapter" rel="prev" role="button" aria-labelledby="previous-label"
+               style="top: 65px;left: 50%;position: fixed;color: #000;height: 24px;background: #d3d3d33b; width: 150px;transform: translate(-50%, 0); display: none">
+                <i class="material-icons black-text" style="left: calc(50% - 12px);
+                position: relative;">keyboard_arrow_up</i>
+            </a>
+            <a id="next-chapter" rel="next" role="button" aria-labelledby="next-label" style="bottom: 0;left: 50%;position: fixed;color: #000;height: 24px;background: #d3d3d33b; width: 150px;transform: translate(-50%, 0); display: none">
+                <i class="material-icons black-text" style="left: calc(50% - 12px);
+                position: relative;">keyboard_arrow_down</i>
+            </a>
+            <div class="left-gutter" id="left-gutter"></div>
+        </div>
+
+    </div>
+
+    <footer id="footerMenu">
+        <a rel="prev" class="disabled" role="button" aria-labelledby="previous-label" style="top: 50%;left:0;position: fixed;height: 100px;
+                    background: #d3d3d33b;">
+            <i class="material-icons black-text" style="top: calc(50% - 12px);
+                        position: relative;">keyboard_arrow_left</i>
+        </a>
+        <a rel="next" class="disabled" role="button" aria-labelledby="next-label" style="top: 50%;right:0;position: fixed;height: 100px;
+                    background: #d3d3d33b;">
+            <i class="material-icons black-text" style="top: calc(50% - 12px);
+                        position: relative;">keyboard_arrow_right</i>
+        </a>
+    </footer>
+
+    <script>
+        let getURLQueryParams = function () {
+            let params = {};
+            let query = window.location.search;
+            if (query && query.length) {
+                query = query.substring(1);
+                let keyParams = query.split('&');
+                for (let x = 0; x < keyParams.length; x++) {
+                    let keyVal = keyParams[x].split('=');
+                    if (keyVal.length > 1) {
+                        params[keyVal[0]] = decodeURIComponent(keyVal[1]);
+                    }
+                }
+            }
+            return params;
+        };
+        let urlParams = getURLQueryParams();
+        let upLink = { url: new URL("/", window.location.href), label: "Back", ariaLabel: "Go back" };
+        let injectables = [
+            { type: 'style', url: '/viewer/readium-css/ReadiumCSS-before.css', r2before: true },
+            { type: 'style', url: '/viewer/readium-css/ReadiumCSS-default.css', r2default: true },
+            { type: 'style', url: '/viewer/readium-css/ReadiumCSS-after.css', r2after: true },
+            { type: 'style', url: '/viewer/injectables/pagebreak/pagebreak.css', r2after: true },
+            { type: 'script', url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_CHTML&latest' },
+            { type: 'style', url: '/viewer/fonts/opendyslexic/opendyslexic.css', fontFamily: 'opendyslexic' },
+            { type: 'style', fontFamily: 'Courier', systemFont: true },
+            { type: 'script', url: '/viewer/injectables/footnotes/footnotes.js' },
+            { type: 'style', url: '/viewer/injectables/footnotes/footnotes.css' },
+            { type: 'style', url: '/viewer/injectables/style/style.css' },
+        ]
+        let injectablesFixed = [
+            { type: 'style', url: '/viewer/injectables/style/style.css' },
+        ]
+        let userSettings = {
+            // appearance: "readium-sepia-on", //readium-default-on, readium-night-on, readium-sepia-on
+            // fontFamily: "serif", //Original, serif, sans-serif
+            // textAlignment: "start", //"auto", "justify", "start"
+            // columnCount: "1", // "auto", "1", "2"
+            // verticalScroll: "readium-scroll-off", //readium-scroll-on, readium-scroll-off,
+            // fontSize: 300,
+            // wordSpacing: 4.0,
+            // letterSpacing: 4.0,
+            // pageMargins: 4.0,
+            // lineHeight: 4.0
+        }
+        let selectionMenuItems = [
+            {
+                id: 'anIcon',
+                callback: function (selection) {
+                    alert(selection)
+                }
+            }
+        ]
+
+        D2Reader.load({
+            upLinkUrl: upLink,
+            url: new URL(urlParams['url']),
+            attributes: {
+                margin: 120,
+                navHeight: 70,
+                iframePaddingTop: 20,
+                bottomInfoHeight: 60,
+                sideNavPosition: 'right'
+            },
+            rights: {
+                enableMaterial: true,
+                enableBookmarks: true,
+                enableAnnotations: false,
+                enableTTS: false,
+                enableSearch: false,
+                enableTimeline: false,
+                enableContentProtection: false,
+                enableMediaOverlays: false,
+                autoGeneratePositions: true,
+            },
+            sample: {
+                isSampleRead: true,
+                limit: 10, // in percent e.g. 5%
+                minimum: 5, // in pages
+                popup: "You can borrow the book to continue reading."
+            },
+            highlighter: {
+                selectionMenuItems: selectionMenuItems,
+                api: {
+                    selectionMenuOpen: function () {
+                        console.log("selectionMenuOpen")
+                    },
+                    selectionMenuClose: function () {
+                        console.log("selectionMenuClose")
+                    },
+                }
+            },
+            bookmarks: {
+                api: {
+                    addBookmark: function (bookmark) {
+                        console.log("addBookmark")
+                        return new Promise(function (resolve, reject) {
+                            bookmark.id = Math.random()
+                            resolve(
+                                bookmark
+                            )
+                        })
+                    },
+                    deleteBookmark: function (bookmark) {
+                        console.log("deleteBookmark")
+                        return new Promise(function (resolve, reject) {
+                            resolve(
+                                bookmark
+                            )
+                        })
+                    }
+                }
+            },
+            protection: {
+                enforceSupportedBrowsers: true,
+                enableEncryption: true,
+                enableObfuscation: true,
+                disablePrint: true,
+                disableCopy: true,
+                detectInspect: false,
+                clearOnInspect: true, // make sure detectInspect is true, otherwise this won't work
+                disableKeys: true,
+                disableContextMenu: true,
+                hideTargetUrl: true,
+                disableDrag: false,
+                supportedBrowsers: [ // this will only be used if enforceSupportedBrowsers is true, and has nothing to do with the r2d2bc modules supported browsers
+                    "Chrome", "ChromeAndroid", "Edge", "Firefox", "iOS", "Safari"
+                ],
+                api: {
+                    // make sure detectInspect is true, otherwise this won't be called
+                    // this callback will be executed in a loop while inspect is visible
+                    inspectDetected: function () {
+                        console.log("inspect detected")
+                    }
+                }
+            },
+            api: {
+                getContent: function (href) {
+                    console.log("getContent")
+                    return new Promise(function (resolve, reject) {
+                        resolve(
+                            // 'test, <a xmlns="http://www.w3.org/1999/xhtml" href="chapter_04.xhtml">Chapter 4</a>'
+                        )
+                    })
+                },
+                resourceReady: function () {
+                    console.log("resourceReady")
+                    // D2Reader.applyUserSettings({fontFamily: 'opendyslexic'})
+                },
+                resourceAtStart:function () {
+                    console.log("resourceAtStart")
+                },
+                resourceAtEnd:function () {
+                    console.log("resourceAtEnd")
+                },
+                resourceFitsScreen:function () {
+                    console.log("resourceFitsScreen")
+                },
+                updateCurrentLocation: function (location) {
+                    console.log("updateCurrentLocation")
+                    return new Promise(function (resolve, reject) {
+                        resolve(
+                            location
+                        )
+                    })
+                },
+                updateSettings: function (settings) {
+                    console.log("updateSettings")
+                    return new Promise(function (resolve, reject) {
+                        resolve(
+                            settings
+                        )
+                    })
+                }
+            },
+            injectables: injectables,
+            injectablesFixed: injectablesFixed,
+            userSettings: userSettings,
+            useLocalStorage: true // true = uses local storage, false = uses session storage (default)
+        }).then(instance => {
+            console.log("D2Reader loaded ", instance);
+            // console.log("instance.bookmarkModule ", instance.bookmarkModule)
+            // console.log("instance.annotationModule ", instance.annotationModule)
+        }).catch(error => {
+            console.error("error.message ", error.message);
+            document.getElementById("reader-error").innerText = error.message
+        });
+
+        function setColor(columnCount) {
+            let buttons = document.getElementById('columnCount').getElementsByTagName('button');
+            if (columnCount == 'auto') {
+                buttons[0].style.backgroundColor = '#d7dcdf'
+                buttons[1].style.backgroundColor = 'white'
+                buttons[2].style.backgroundColor = 'white'
+            } else if (columnCount == '1') {
+                buttons[1].style.backgroundColor = '#d7dcdf'
+                buttons[0].style.backgroundColor = 'white'
+                buttons[2].style.backgroundColor = 'white'
+            } else if (columnCount === '2') {
+                buttons[2].style.backgroundColor = '#d7dcdf'
+                buttons[0].style.backgroundColor = 'white'
+                buttons[1].style.backgroundColor = 'white'
+            }
+        }
+
+        function setScroll(scroll) {
+            let buttons = document.getElementById('scrollMode').getElementsByTagName('button');
+            if (scroll === 'true') {
+                buttons[0].style.backgroundColor = '#d7dcdf'
+                buttons[1].style.backgroundColor = 'white'
+            } else if (scroll === 'false') {
+                buttons[1].style.backgroundColor = '#d7dcdf'
+                buttons[0].style.backgroundColor = 'white'
+            }
+        }
+
+        function setAlignment(textAlignment) {
+            let buttons = document.getElementById('textAlignment').getElementsByTagName('button');
+            if (textAlignment === 'auto') {
+                buttons[0].style.backgroundColor = '#d7dcdf'
+                buttons[1].style.backgroundColor = 'white'
+                buttons[2].style.backgroundColor = 'white'
+            } else if (textAlignment === 'justify') {
+                buttons[1].style.backgroundColor = '#d7dcdf'
+                buttons[0].style.backgroundColor = 'white'
+                buttons[2].style.backgroundColor = 'white'
+            } else if (textAlignment === 'start') {
+                buttons[2].style.backgroundColor = '#d7dcdf'
+                buttons[0].style.backgroundColor = 'white'
+                buttons[1].style.backgroundColor = 'white'
+            }
+        }
+        function reload() {
+            D2Reader.currentSettings().then(
+                result => {
+                    console.log(JSON.stringify(result))
+                    document.getElementById("fontSize").value = result['fontSize'];
+                    document.getElementById("fontFamily").value = result['fontFamily'];
+
+                    let buttonsScroll = document.getElementById('scrollMode').getElementsByTagName('button');
+                    let scrollMode = result['verticalScroll']
+                    if (scrollMode === true) {
+                        buttonsScroll[0].style.backgroundColor = '#d7dcdf'
+                    } else if (scrollMode === false) {
+                        buttonsScroll[1].style.backgroundColor = '#d7dcdf'
+                    }
+
+                })
+
+        }
+    </script>
+
+    <!-- START Material Scripts -->
+    <!-- Compiled and minified Materialize JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+
+    <noscript>
+        <style>
+            noscript {
+                width: 100%;
+                height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+
+            .warning {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                font-size: 1.5rem;
+                font-weight: bold;
+            }
+        </style>
+        <p class="warning">To use this viewer, please enable JavaScript.</p>
+    </noscript>
+</body>
+
+</html>


### PR DESCRIPTION
This Feature allows any publication to be restricted as Sample or Preview.

how to use it:

in the reader config add the following section:

```
sample: {
     isSampleRead: true,
     limit: 10, // in percent e.g. 10%
     minimum: 5, // in pages
     popup: "You can borrow the book to continue reading." // any text that should be shown as overlay when the limit is reached
},
```

* minimum:
the minimum is the fallback for FXL publications, if the limit (in %) results in less than the minimum pages, for example:
10% of a FXL with 27 pages is 2 pages, that's not a lot, so if the minimum is greater than the pages resulting through the limit, than the minimum is used. 

Sample read is not a module, it's just a configuration to define the publication that is being rendered as sample read and limit reading beyond the set limits or minimum.

Please note: SampleRead relies on positions, so if you have disabled positions, SampleRead won't be able to calculate and compare based on percentage. 


you could have generation positions disabled:
```
rights: {
     autoGeneratePositions: false,
}
```
but if you provide services where the positions have been preprocessed, it would still work. as long as positions are available.
```
services: {
     positions: new URL("https://.../positions.json"),
},

```