### PR TITLE
Adds fallback for locations object

### DIFF
--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -75,15 +75,16 @@ export class Publication extends R2Publication {
   public getSpineIndex(href: string): number | null {
     return this.readingOrder.findIndex(
       (item) =>
-        item.Href && new URL(item.Href, this.manifestUrl.href).href === href
+        item.Href && this.getAbsoluteHref(item.Href) === href
     );
   }
 
   public getAbsoluteHref(href: string): string | null {
     return new URL(href, this.manifestUrl.href).href;
   }
+
   public getRelativeHref(href: string): string | null {
-    const manifest = this.manifestUrl.href.replace("/manifest.json", ""); //new URL(this.manifestUrl.href, this.manifestUrl.href).href;
+    const manifest = this.manifestUrl.href.replace("/manifest.json", "");
     let h = href.replace(manifest, "");
     if (h.indexOf("#") > 0) {
       h = h.slice(0, h.indexOf("#"));
@@ -104,7 +105,7 @@ export class Publication extends R2Publication {
             item.Href.indexOf("#") !== -1
               ? item.Href.slice(0, item.Href.indexOf("#"))
               : item.Href;
-          const itemUrl = new URL(hrefAbsolutre, this.manifestUrl.href).href;
+          const itemUrl = this.getAbsoluteHref(hrefAbsolutre);
           if (itemUrl === href) {
             return item;
           }
@@ -130,7 +131,7 @@ export class Publication extends R2Publication {
       for (let index = 0; index < links.length; index++) {
         const item = links[index] as Link;
         if (item.Href) {
-          const itemUrl = new URL(item.Href, this.manifestUrl.href).href;
+          const itemUrl = this.getAbsoluteHref(item.Href);
           if (itemUrl === href) {
             return item;
           }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2393,11 +2393,12 @@ export default class IFrameNavigator implements Navigator {
     this.handleNextChapterClick(null);
   }
   goTo(locator: Locator): any {
-    let locations: Locations = locator.locations;
+    let locations: Locations = locator.locations ?? { progression: 0 };
     if (locator.href.indexOf("#") !== -1) {
       const elementId = locator.href.slice(locator.href.indexOf("#") + 1);
       if (elementId !== null) {
         locations = {
+          ...locations,
           fragment: elementId,
         };
       }


### PR DESCRIPTION
We are using the `D2Reader.goTo` function to navigate to TOC locations. `goTo` calls `IframeNavigator.navigate(locator)`, which now includes code that inspects the given `locator.locations` object. This was resulting in an error for us when we tried to navigate via the TOC: 

![navigate](https://user-images.githubusercontent.com/21145027/130125866-3a460321-400e-44f5-8844-95b7627adfff.png)

To fix this, I just ensured that the `locations` object exists in `goTo`.