### PR TITLE
bugfix - Ensure keyboard event listener on window.document is only attached once

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -261,6 +261,7 @@ export default class IFrameNavigator implements Navigator {
   injectables: Array<Injectable>;
   attributes: IFrameAttributes;
   services: PublicationServices;
+  private didInitKeyboardEventHandler: boolean = false;
 
   public static async create(config: IFrameNavigatorConfig): Promise<any> {
     const navigator = new this(
@@ -1536,8 +1537,11 @@ export default class IFrameNavigator implements Navigator {
           this.touchEventHandler.setupEvents(iframe.contentDocument);
           this.keyboardEventHandler.setupEvents(iframe.contentDocument);
         }
-        this.keyboardEventHandler.delegate = this;
-        this.keyboardEventHandler.keydown(document);
+        if (!this.didInitKeyboardEventHandler) {
+          this.keyboardEventHandler.delegate = this;
+          this.keyboardEventHandler.keydown(document);
+          this.didInitKeyboardEventHandler = true;
+        }
       }
       if (this.view.layout !== "fixed") {
         if (this.view?.isScrollMode()) {


### PR DESCRIPTION
`handleIframeLoad` is currently attaching the "keydown" event to the parent `window.document` every time the iframe load event fires. So, if you load new content into the iframe multiple times, pressing arrow left or right will skip a corresponding number of pages (in pagination mode).

The fix was to ensure that the event is only attached to the document element once during the first iframe "load" event. Thank you. 