### PR TITLE
KeyHandler: Ignore events in inputs or when active selection

### DIFF
--- a/src/utils/KeyboardEventHandler.ts
+++ b/src/utils/KeyboardEventHandler.ts
@@ -46,6 +46,20 @@ export default class KeyboardEventHandler {
     element.addEventListener(
       "keydown",
       function (event: KeyboardEvent) {
+        // Ignore input elements
+        const eventTarget = event.target as HTMLElement;
+        if (/input|select|option|textarea/i.test(eventTarget.tagName)) {
+          return;
+        }
+
+        // Ignore when active text selection
+        const ownerDocument = (eventTarget.ownerDocument || eventTarget) as HTMLDocument;
+        const ownerWindow = ownerDocument.defaultView as Window;
+        const selection = ownerWindow.getSelection() as Selection;
+        if (!selection.isCollapsed) {
+          return;
+        }
+
         const key = event.key;
         switch (key) {
           case "ArrowRight":


### PR DESCRIPTION
Since this event handler only deals with left/right arrows, we can safely ignore these in certain circumstances.
Allows for cursor movement in inputs and expanding/contracting a text selection via keyboard.

Note: Text selection adjustment needs to use Ctrl-Arrow to expand/contract by words due to auto-expanding override of selector.