### PR TITLE
Expand the descramble area

### DIFF
--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -967,8 +967,15 @@ export default class ContentProtectionModule implements ReaderModule {
     const isAbove = bottom < windowTop;
     const isBelow = rect.top > windowBottom;
 
-    const isLeft = right < windowLeft;
-    const isRight = rect.left > windowRight;
+    // Consider left boundary to be one full screen width left of the leftmost
+    // edge of the viewing area. This is so text originating on the previous
+    // screen does not flow onto the current screen scrambled.
+    const isLeft = right < (windowLeft - window.innerWidth);
+
+    // Consider right boundary to be one full screen width right of the rightmost
+    // edge of the viewing area. This is so quickly paging through the book
+    // does not result in visible page descrambling.
+    const isRight = rect.left > (windowRight + window.innerWidth);
 
     return isAbove || isBelow || isLeft || isRight;
   }


### PR DESCRIPTION
Expand the descramble area to include one full screen width before and after the viewing area.

From @jdempcy: 

"Expand width of descramble area. I verified by trying to print that the descramble still works - it's still descrambled, I just no longer see descrambling artifacts when paging quickly, or scrambled text in the top-left paragraph when that paragraph originated on the previous screen."

Related to this PR: https://github.com/d-i-t-a/R2D2BC/pull/261
