### PR TITLE
Add setIframeHeight method to paginated state

### DIFF
--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -97,6 +97,7 @@ export default class ReflowableBookView implements BookView {
       ) as any;
       html.style.setProperty("--USER__scroll", "readium-scroll-off");
       this.setSize();
+      this.setIframeHeight(this.iframe);
     }
     if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.recalculate();

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -84,6 +84,8 @@ export default class ReflowableBookView implements BookView {
       this.setSize();
       this.setIframeHeight(this.iframe);
     } else {
+      this.height =
+        BrowserUtilities.getHeight() - 40 - this.delegate.attributes.margin;
       this.name = "readium-scroll-off";
       this.label = "Paginated";
       // any is necessary because CSSStyleDeclaration type does not include
@@ -97,7 +99,6 @@ export default class ReflowableBookView implements BookView {
       ) as any;
       html.style.setProperty("--USER__scroll", "readium-scroll-off");
       this.setSize();
-      this.setIframeHeight(this.iframe);
     }
     if (this.delegate.rights?.enableContentProtection) {
       this.delegate.contentProtectionModule.recalculate();


### PR DESCRIPTION
This PR fixes the iframe height issue when switching scroll mode to paginated mode from the initial load.

An issue I was having while using the v2-branch was that when I reload the page on scroll mode and switch to paginated mode, the iframe height was 0, causing a blank page. 

The following proposed fix is to add the `this.setIframeHeight(this.iframe);` method to [setMode](https://github.com/d-i-t-a/R2D2BC/blob/1c11193d83d75957c97f8ae921a14564073b027b/src/views/ReflowableBookView.ts#L49).
