### PR TITLE
Bugfix: next page button becomes inoperable on scrollMode for some books

### DIFF
--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -62,6 +62,7 @@ const App = () => {
             id="iframe-wrapper"
             style={{
               height: "calc(100vh - 10px)",
+              overflow: "hidden",
             }}
           >
             <div id="reader-loading" className="loading"></div>

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -325,7 +325,7 @@ export default class ReflowableBookView implements BookView {
         "#iframe-wrapper"
       ) as HTMLDivElement;
       return (
-        Math.ceil(this.scrollingElement.scrollHeight - wrapper.scrollTop) - 1 <=
+        Math.ceil(this.scrollingElement.clientHeight - wrapper.scrollTop) - 1 <=
         BrowserUtilities.getHeight()
       );
     } else {

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -84,8 +84,6 @@ export default class ReflowableBookView implements BookView {
       this.setSize();
       this.setIframeHeight(this.iframe);
     } else {
-      this.height =
-        BrowserUtilities.getHeight() - 40 - this.delegate.attributes.margin;
       this.name = "readium-scroll-off";
       this.label = "Paginated";
       // any is necessary because CSSStyleDeclaration type does not include

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -84,6 +84,8 @@ export default class ReflowableBookView implements BookView {
       this.setSize();
       this.setIframeHeight(this.iframe);
     } else {
+      this.height =
+        BrowserUtilities.getHeight() - 40 - this.delegate.attributes.margin;
       this.name = "readium-scroll-off";
       this.label = "Paginated";
       // any is necessary because CSSStyleDeclaration type does not include
@@ -325,7 +327,7 @@ export default class ReflowableBookView implements BookView {
         "#iframe-wrapper"
       ) as HTMLDivElement;
       return (
-        Math.ceil(this.scrollingElement.clientHeight - wrapper.scrollTop) - 1 <=
+        Math.ceil(this.scrollingElement.scrollHeight - wrapper.scrollTop) - 1 <=
         BrowserUtilities.getHeight()
       );
     } else {


### PR DESCRIPTION
This PR updates the atEnd function to use `clientHeight` instead of `scrollHeight` for calculating the remaining page content.

The bug appears when loading a reflowed page on scroll mode on firefox. On scroll mode, some margin and padding were added through CSS to the  <body> tag inside the Iframe document, making the Iframe to overflow, clientHeight returns the actual viewable height of the document, which is what we want.

## To Reproduce

- run `npm run example:react` with this book. https://drb-files-qa.s3.amazonaws.com/epubs/gutenberg/65303_noimages/manifest.json
- Switch to scroll mode, the next page button does not take you to the next resource.