### PR TITLE
Scrolling mode fixes so to enable resource navigation

### DIFF
--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -62,7 +62,7 @@ const App = () => {
             id="iframe-wrapper"
             style={{
               height: "calc(100vh - 10px)",
-              overflow: "hidden",
+              overflow: "auto",
             }}
           >
             <div id="reader-loading" className="loading"></div>

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1558,7 +1558,7 @@ export default class IFrameNavigator implements Navigator {
             (this.newPosition as Annotation).highlight.selectionInfo.rangeInfo
               .startContainerElementCssSelector
           );
-        } else if (bookViewPosition > 0) {
+        } else if (bookViewPosition >= 0) {
           this.view.goToProgression(bookViewPosition);
         }
 
@@ -2819,7 +2819,6 @@ export default class IFrameNavigator implements Navigator {
           type: this.nextChapterLink.type,
           title: this.nextChapterLink.title,
         };
-
         this.stopReadAloud();
         this.navigate(position);
       }
@@ -3026,7 +3025,6 @@ export default class IFrameNavigator implements Navigator {
           if (this.chapterTitle)
             this.chapterTitle.innerHTML = "(Current Chapter)";
         }
-
         await this.updatePositionInfo();
       } else {
         if (this.searchModule !== undefined) {

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -452,16 +452,18 @@ export default class ReflowableBookView implements BookView {
   setIframeHeight(iframe: any) {
     let d = debounce((iframe: any) => {
       if (iframe) {
-        let iframeWin =
-          iframe.contentWindow || iframe.contentDocument.parentWindow;
-        if (iframeWin.document.body) {
-          const minHeight =
-            BrowserUtilities.getHeight() - this.attributes.margin;
-          const bodyHeight =
-            iframeWin.document.documentElement.scrollHeight ||
-            iframeWin.document.body.scrollHeight;
-          iframe.height = Math.max(minHeight, bodyHeight);
-        }
+        let body = iframe.contentWindow.document.body,
+          html = iframe.contentWindow.document.documentElement;
+
+        let height = Math.max(
+          body.scrollHeight,
+          body.offsetHeight,
+          html.clientHeight,
+          html.scrollHeight,
+          html.offsetHeight
+        );
+        const minHeight = BrowserUtilities.getHeight() - this.attributes.margin;
+        iframe.height = Math.max(minHeight, height) + "px";
       }
     }, 200);
     d(iframe);
@@ -490,10 +492,8 @@ export default class ReflowableBookView implements BookView {
         this.height + "px";
       this.iframe.height = this.height + "px";
     } else {
-      let body = this.iframe.contentWindow.document.body;
-      if (body) {
-        this.iframe.height = parseInt(getComputedStyle(body).height) + "px";
-      }
+      let html = this.iframe.contentWindow.document.documentElement;
+      this.iframe.height = html.offsetHeight + "px";
     }
   }
 


### PR DESCRIPTION
One note:  it looks like the "previous resource" now has a similar problem where it doesn't reset - eg - if you're navigating from a larger resource to a smaller one, the iframe retains the height of the larger resource.  With the scrollbar, this doesn't impede our launch, I think, but it's a thing that we've introduced here and I wanted to bring it up in case it's a symptom of a larger problem.  

edit:  I don't think it's an updating issue - it looks like the file keeps getting bigger the more resources you load - this might be something that blocks merging ... 