### PR TITLE
Fix/parent element null

### DIFF
--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -414,7 +414,7 @@ export default class ReflowableBookView implements BookView {
   }
 
   isScrollMode() {
-    if (this.iframe) {
+    if (this.iframe && this.iframe.contentDocument) {
       const html = HTMLUtilities.findRequiredIframeElement(
         this.iframe.contentDocument,
         "html"


### PR DESCRIPTION
I would sometimes get an error that "parent element is null" and now that I have a stack trace with it, I traced it back to this point. I'm not sure why `this.iframe` would exist and `this.iframe.contentDocument` would be null, but it seems that does happen occasionally. This should fix it. 