### PR TITLE
bugfix - Removes use of debugger checker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cssesc": "^3.0.0",
         "debounce": "^1.2.1",
         "detect-browser": "^5.2.0",
-        "devtools-detector": "^2.0.3",
+        "devtools-detector": "^2.0.6",
         "jscrypto": "0.0.1",
         "lodash.clonedeep": "^4.5.0",
         "mark.js": "^8.11.1",
@@ -2465,9 +2465,9 @@
       "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "node_modules/devtools-detector": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.3.tgz",
-      "integrity": "sha512-arZgrtJk9Rd5YTdKcNWlVTsGlbqLFFxnfB61P039drbmZPM6/SFL/jMG5OdtcCSYRZpeht8C6Q/WCuIqAvpSCQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.6.tgz",
+      "integrity": "sha512-O90rhU1MB2Vd/Yq22htRDfELPTOlRr+wemHLkXINlNRSzVn8dk7nnc2dPwLMyqac9ZC3d3vexLYWuwvx7wYIuQ==",
       "dependencies": {
         "compare-versions": "^3.6.0"
       }
@@ -12871,9 +12871,9 @@
       "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "devtools-detector": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.3.tgz",
-      "integrity": "sha512-arZgrtJk9Rd5YTdKcNWlVTsGlbqLFFxnfB61P039drbmZPM6/SFL/jMG5OdtcCSYRZpeht8C6Q/WCuIqAvpSCQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.6.tgz",
+      "integrity": "sha512-O90rhU1MB2Vd/Yq22htRDfELPTOlRr+wemHLkXINlNRSzVn8dk7nnc2dPwLMyqac9ZC3d3vexLYWuwvx7wYIuQ==",
       "requires": {
         "compare-versions": "^3.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "cssesc": "^3.0.0",
     "debounce": "^1.2.1",
     "detect-browser": "^5.2.0",
-    "devtools-detector": "^2.0.3",
+    "devtools-detector": "^2.0.6",
     "jscrypto": "0.0.1",
+    "lodash.clonedeep": "^4.5.0",
     "mark.js": "^8.11.1",
     "promise-polyfill": "^8.2.0",
-    "sentence-splitter": "^3.2.1",
-    "lodash.clonedeep": "^4.5.0",
     "r2-shared-js": "^1.0.51",
     "sanitize-html": "^2.3.3",
+    "sentence-splitter": "^3.2.1",
     "whatwg-fetch": "^3.6.2"
   },
   "browserslist": {

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -27,7 +27,7 @@ import {
 import { debounce } from "debounce";
 import { IS_DEV } from "../../utils";
 import { delay } from "../../utils";
-import { addListener, launch } from "devtools-detector";
+import { DevtoolsDetector, checkers } from "devtools-detector";
 import { getUserAgentRegExp } from "browserslist-useragent-regexp";
 
 export interface ContentProtectionModuleProperties {
@@ -119,8 +119,17 @@ export default class ContentProtectionModule implements ReaderModule {
         config.api.inspectDetected();
       }
     };
-    addListener(onInspectorOpened);
-    launch();
+    const detector = new DevtoolsDetector({
+      checkers: [
+        checkers.elementIdChecker,
+        checkers.regToStringChecker,
+        checkers.functionToStringChecker,
+        checkers.depRegToStringChecker,
+        checkers.dateToStringChecker,
+      ],
+    })
+    detector.addListener(onInspectorOpened);
+    detector.launch();
     await delay(config.detectInspectInitDelay ?? 50);
   }
 
@@ -740,8 +749,11 @@ export default class ContentProtectionModule implements ReaderModule {
     if (IS_DEV) {
       console.log("before print");
     }
-    this.delegate.headerMenu.style.display = "none";
-    this.delegate.mainElement.style.display = "none";
+
+    if (this.delegate && this.delegate.headerMenu) {
+      this.delegate.headerMenu.style.display = "none";
+      this.delegate.mainElement.style.display = "none";
+    }
 
     event.stopPropagation();
     event.preventDefault();
@@ -752,10 +764,13 @@ export default class ContentProtectionModule implements ReaderModule {
     stopPropagation: () => void;
   }) {
     if (IS_DEV) {
-      console.log("before print");
+      console.log("after print");
     }
-    this.delegate.headerMenu.style.removeProperty("display");
-    this.delegate.mainElement.style.removeProperty("display");
+
+    if (this.delegate && this.delegate.headerMenu) {
+      this.delegate.headerMenu.style.removeProperty("display");
+      this.delegate.mainElement.style.removeProperty("display");
+    }
 
     event.stopPropagation();
     event.preventDefault();


### PR DESCRIPTION
This PR updates the devtools detector library in order to remove use of the lib's "debugger checker", which forced only Chrome to "pause" on a debugger statement every time you opened in the devtools in content protection/detect inspect mode. The point of allowing the user to detect inspection is to protect against someone maliciously accessing the JS console, or inspecting the state of the DOM. This arbitrary debugger "pause" in chrome made it possible to still make use of the browser's dev tools. Luckily, this behavior can be removed simply by explicitly opting out of the debugger checker in the code, as I do in this PR.  