### PR TITLE
Refactor isEpubInternal logic

### DIFF
--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -20,6 +20,7 @@
 import { IS_DEV } from "../utils";
 import IFrameNavigator from "../navigator/IFrameNavigator";
 import Popup from "../modules/search/Popup";
+import { Link } from "r2-shared-js/dist/es6-es2015/src/models/publication-link";
 
 export function addEventListenerOptional(
   element: any,
@@ -79,6 +80,28 @@ export default class EventHandler {
     return null;
   };
 
+  /**
+   *
+   * This function checks the user clicked link inside the iframe
+   * against the tableOfContents, it is an internal link if found.
+   *
+   */
+  private isEpubInternal = (clickedLink: HTMLAnchorElement): boolean => {
+    if (IS_DEV) console.log("clickedLink: ", clickedLink);
+
+    const linkInReadingOrder = (
+      readingOrder: Link[],
+      clickedPathname: string
+    ) => readingOrder.some((link: Link) => clickedPathname.includes(link.Href));
+
+    const isEpubInternal = linkInReadingOrder(
+      this.navigator.publication.readingOrder,
+      clickedLink.pathname
+    );
+
+    return isEpubInternal;
+  };
+
   private handleLinks = async (
     event: MouseEvent | TouchEvent
   ): Promise<void> => {
@@ -93,12 +116,7 @@ export default class EventHandler {
         window.location.hostname === link.hostname;
 
       // If epub is hosted, rather than streamed, links to a resource inside the same epub should not be opened externally.
-      const manifestUrl = this.navigator.publication.manifestUrl;
-
-      const isEpubInternal =
-        manifestUrl.protocol === link.protocol &&
-        manifestUrl.port === link.port &&
-        manifestUrl.hostname === link.hostname;
+      const isEpubInternal = this.isEpubInternal(link);
 
       const isInternal = link.href.indexOf("#");
       if (!isSameOrigin && !isEpubInternal) {

--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -92,7 +92,11 @@ export default class EventHandler {
     const linkInReadingOrder = (
       readingOrder: Link[],
       clickedPathname: string
-    ) => readingOrder.some((link: Link) => clickedPathname.includes(link.Href));
+    ) =>
+      readingOrder.some(
+        (link: Link) =>
+          !link.Rel?.includes("external") && clickedPathname.includes(link.Href)
+      );
 
     const isEpubInternal = linkInReadingOrder(
       this.navigator.publication.readingOrder,

--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -83,7 +83,7 @@ export default class EventHandler {
   /**
    *
    * This function checks the user clicked link inside the iframe
-   * against the tableOfContents, it is an internal link if found.
+   * against the readingOrder list, it is an internal link if found.
    *
    */
   private isEpubInternal = (clickedLink: HTMLAnchorElement): boolean => {


### PR DESCRIPTION
This PR refactors the isEpubInternal logic for handling internal epub link navigation. 

Instead of checking the webpubmanfiest URL, we now search if the clicked link is in the readerOrder from the publication. This update handles cases where clickable internal links should always be navigable internally, and handles cases when webpub manifest contains absolute links.