### PR TITLE
Fix internal link search to account for absolute link

### DIFF
--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -95,7 +95,7 @@ export default class EventHandler {
     ) =>
       readingOrder.some(
         (link: Link) =>
-          !link.Rel?.includes("external") && clickedPathname.includes(link.Href)
+          !link.Rel?.includes("external") && link.Href.includes(clickedPathname)
       );
 
     const isEpubInternal = linkInReadingOrder(


### PR DESCRIPTION
This PR fixes a logic from the previous isEpubInternal work where when manifest contains an absolute URL, the `isEpubInternal` would return false.