### PR TITLE
Reset iframe height on each load

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1380,6 +1380,10 @@ export default class IFrameNavigator implements Navigator {
       if (this.newPosition) {
         bookViewPosition = this.newPosition.locations.progression;
       }
+
+      // Reset before setIframeHeight is called to calculate the height.
+      this.iframes[0].height = "0px";
+
       await this.handleResize();
       this.updateBookView();
 


### PR DESCRIPTION
I am experiencing a bug on some contents that, when a user navigates to a page with a large resource and navigates back, the iframe keeps the largest height value for the iframe, which results in a page with excessive blank areas.

### To Reproduce
1. Replace the [example book](https://github.com/d-i-t-a/R2D2BC/blob/1e374e820fdf625e9f3918abc085e414c951fb70/examples/react/index.tsx#L19) with this. https://drb-files-qa.s3.amazonaws.com/epubs/gutenberg/65303_noimages/manifest.json
2. run `npm run example:react`, and open the page on Chrome or Safari
3. Turn on 'scrolling mode', and get to page 2
4. Now if you press the back button, and get to page 1, you will see a huge page with a large blank area under the cover page and a big vertical scroll bar.

I assume it was because when the iframe loads, it somehow saves the old iframe height value or a race condition somewhere that made the 'setIframeHeight` function references the previous iframe instance.

This PR resets the iframe height before it loads the content, and it seems to be working fine on chrome, safari, or firefox. This seems trivial and I am not sure if this is the right place to set this, please let me know what you think!

