### PR TITLE
recalculate in handleIframeLoad

### DIFF
--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -838,21 +838,28 @@ export default class ContentProtectionModule implements ReaderModule {
     }
   }
 
-  recalculate(delay: number = 0) {
-    if (this.properties?.enableObfuscation) {
-      const onDoResize = debounce(() => {
-        this.calcRects(this.rects);
-        if (this.rects !== undefined) {
-          this.rects.forEach((rect) =>
-            this.toggleRect(rect, this.securityContainer, this.isHacked)
-          );
+  recalculate(delay: number = 0): Promise<boolean> {
+    return new Promise(resolve => {
+      if (this.properties?.enableObfuscation) {
+          const onDoResize = debounce(() => {
+            this.calcRects(this.rects);
+            if (this.rects !== undefined) {
+              this.rects.forEach((rect) =>
+                this.toggleRect(rect, this.securityContainer, this.isHacked)
+              );
+            }
+            resolve(true);
+          }, delay);
+        if (this.rects) {
+          this.observe();
+          onDoResize();
+        } else {
+          resolve(false);
         }
-      }, delay);
-      if (this.rects) {
-        this.observe();
-        onDoResize();
+      } else {
+        resolve(false);
       }
-    }
+    });
   }
 
   calcRects(rects: Array<ContentProtectionRect>): void {

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1601,8 +1601,13 @@ export default class IFrameNavigator implements Navigator {
         } else if (bookViewPosition > 0) {
           this.view.goToProgression(bookViewPosition);
         }
-
         this.newPosition = null;
+
+        if (this.rights?.enableContentProtection) {
+          if (this.contentProtectionModule !== undefined) {
+            await this.contentProtectionModule.recalculate(10);
+          }
+        }
 
         this.hideLoadingMessage();
         this.showIframeContents();


### PR DESCRIPTION
It's necessary to call `this.contentProtectionModule.recalculate` if the active book position is advanced beyond the beginning of a chapter in `handleIframeLoad`. Otherwise, the text appears scrambled:

![content_is_scrambled](https://user-images.githubusercontent.com/21145027/151254066-926e57cb-3dbc-4573-8b55-7a2309e15c0e.png)
