### PR TITLE
Updated devtools-detector to 2.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "browserslist-useragent": "^3.0.3",
         "cssesc": "^3.0.0",
         "detect-browser": "^5.2.0",
-        "devtools-detector": "^2.0.10",
+        "devtools-detector": "^2.0.14",
         "eventemitter3": "^4.0.7",
         "jscrypto": "^1.0.3",
         "lodash.clonedeep": "^4.5.0",
@@ -4229,9 +4229,9 @@
       }
     },
     "node_modules/devtools-detector": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.10.tgz",
-      "integrity": "sha512-6UDNU88Va/lC0PMeRijVuRH6CW8nzv1xZdru9OvVepDi5euyDNjpDmjdvCKEmqjDpwU6fdfrwad+JIo7ruBp5w==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.14.tgz",
+      "integrity": "sha512-lI7zNCDL+a6jusFIYG5zztJSGt6gNV+rtoDAm9Z00MhHKMHQxh58oLYLz0xlv0tFwbzl1S0Qq6P87iznwwEcGw==",
       "dependencies": {
         "compare-versions": "^3.6.0"
       }
@@ -14455,9 +14455,9 @@
       "dev": true
     },
     "devtools-detector": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.10.tgz",
-      "integrity": "sha512-6UDNU88Va/lC0PMeRijVuRH6CW8nzv1xZdru9OvVepDi5euyDNjpDmjdvCKEmqjDpwU6fdfrwad+JIo7ruBp5w==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/devtools-detector/-/devtools-detector-2.0.14.tgz",
+      "integrity": "sha512-lI7zNCDL+a6jusFIYG5zztJSGt6gNV+rtoDAm9Z00MhHKMHQxh58oLYLz0xlv0tFwbzl1S0Qq6P87iznwwEcGw==",
       "requires": {
         "compare-versions": "^3.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "browserslist-useragent": "^3.0.3",
     "cssesc": "^3.0.0",
     "detect-browser": "^5.2.0",
-    "devtools-detector": "^2.0.10",
+    "devtools-detector": "^2.0.14",
     "eventemitter3": "^4.0.7",
     "jscrypto": "^1.0.3",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
Third time's the charm! This is a PR for updating devtools-detector to min. 2.0.14, which is a version that fixes the issue where the 500-item JSON object was being logged by performance.checker.ts 25 times on every page load, making it difficult to develop in Remix (where the logs are outputted in the terminal by the server).