### PR TITLE
Feature/improve annotations loading flow

### DIFF
--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -492,9 +492,7 @@ export class AnnotationModule implements ReaderModule {
   public showHighlights() {
     let highlights: Array<any> = [];
     if (this.annotator) {
-      highlights = this.annotator.getAnnotationsByChapter(
-        this.delegate.currentLocator().href
-      ) as Array<any>;
+      highlights = this.annotator.getAnnotations() as Array<any>;
       if (highlights) {
         highlights = highlights.filter(
           (rangeRepresentation) =>

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -492,7 +492,9 @@ export class AnnotationModule implements ReaderModule {
   public showHighlights() {
     let highlights: Array<any> = [];
     if (this.annotator) {
-      highlights = this.annotator.getAnnotations() as Array<any>;
+      highlights = this.annotator.getAnnotationsByChapter(
+        this.delegate.currentLocator().href
+      ) as Array<any>;
       if (highlights) {
         highlights = highlights.filter(
           (rangeRepresentation) =>
@@ -517,7 +519,9 @@ export class AnnotationModule implements ReaderModule {
       if (this.api) {
         let highlights: Array<any> = [];
         if (this.annotator) {
-          highlights = this.annotator.getAnnotations() as Array<any>;
+          highlights = this.annotator.getAnnotationsByChapter(
+            this.delegate.currentLocator().href
+          ) as Array<any>;
         }
         if (
           this.highlighter &&
@@ -599,7 +603,9 @@ export class AnnotationModule implements ReaderModule {
       } else {
         let highlights: Array<any> = [];
         if (this.annotator) {
-          highlights = this.annotator.getAnnotations() as Array<any>;
+          highlights = this.annotator.getAnnotationsByChapter(
+            this.delegate.currentLocator().href
+          ) as Array<any>;
         }
         if (
           this.highlighter &&
@@ -693,16 +699,18 @@ export class AnnotationModule implements ReaderModule {
         this.delegate.view?.isScrollMode() &&
         this.properties?.enableComments
       ) {
-        this.commentGutter.style.removeProperty("display");
+        this.commentGutter?.style.removeProperty("display");
       } else {
-        this.commentGutter.style.setProperty("display", "none");
+        this.commentGutter?.style.setProperty("display", "none");
       }
       if (this.commentGutter && this.delegate.view?.isScrollMode()) {
         this.commentGutter.innerHTML = "";
 
         let highlights: Array<any> = [];
         if (this.annotator) {
-          highlights = this.annotator.getAnnotations() as Array<any>;
+          highlights = this.annotator.getAnnotationsByChapter(
+            this.delegate.currentLocator().href
+          ) as Array<any>;
           if (highlights) {
             highlights = highlights.filter(
               (rangeRepresentation) =>

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -885,7 +885,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
   }
 
   isScrolling: boolean;
-  private updateBookView(): void {
+  private updateBookView(options?: { skipDrawingAnnotations?: boolean }): void {
     if (this.view?.layout === "fixed") {
       if (this.nextPageAnchorElement)
         this.nextPageAnchorElement.style.display = "none";
@@ -1093,7 +1093,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           await this.pageBreakModule.drawPageBreaks();
         }
 
-        if (this.annotationModule !== undefined) {
+        if (
+          !options?.skipDrawingAnnotations &&
+          this.annotationModule !== undefined
+        ) {
           await this.annotationModule.drawHighlights();
         }
         if (this.bookmarkModule !== undefined) {
@@ -1284,7 +1287,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         bookViewPosition = this.newPosition.locations.progression;
       }
       await this.handleResize();
-      this.updateBookView();
+      this.updateBookView({ skipDrawingAnnotations: true });
 
       await this.settings.applyProperties();
 
@@ -2781,6 +2784,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           return;
         }
       }
+
+      // isCurrentLoaded represents if the navigation goes to a different chapter
+      // Going to a chapter also triggers handleIFrameLoad
       if (isCurrentLoaded) {
         if (locator.href.indexOf("#") !== -1) {
           const elementId = locator.href.slice(locator.href.indexOf("#") + 1);
@@ -2960,15 +2966,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           this.contentProtectionModule.recalculate(300);
         }
 
-        if (this.annotationModule !== undefined) {
-          await this.annotationModule.drawHighlights();
-          await this.annotationModule.showHighlights();
-        }
         if (this.bookmarkModule !== undefined) {
           await this.bookmarkModule.drawBookmarks();
           await this.bookmarkModule.showBookmarks();
         }
-
         if (this.pageBreakModule !== undefined) {
           await this.highlighter?.destroyHighlights(HighlightType.PageBreak);
           await this.pageBreakModule.drawPageBreaks();

--- a/src/store/Annotator.ts
+++ b/src/store/Annotator.ts
@@ -36,6 +36,7 @@ interface Annotator {
   deleteAnnotation(id: any): any;
   deleteSelectedAnnotation(annotation: any): any;
   getAnnotations(): any;
+  getAnnotationsByChapter(chapter: string): any;
   getAnnotation(annotation: IHighlight): any;
   getAnnotationByID(id: string): any;
   getAnnotationPosition(id: any, iframeWin: any): any;

--- a/src/store/LocalAnnotator.ts
+++ b/src/store/LocalAnnotator.ts
@@ -275,6 +275,25 @@ export default class LocalAnnotator implements Annotator {
     return [];
   }
 
+  public getAnnotationsByChapter(chapter: string): any {
+    const savedAnnotations = this.store.get(LocalAnnotator.ANNOTATIONS);
+    if (savedAnnotations) {
+      let annotations = JSON.parse(savedAnnotations);
+      annotations = annotations.filter(
+        (annotation) => annotation.href === chapter
+      );
+      annotations = annotations.sort((n1: Annotation, n2: Annotation) => {
+        if (n1.locations.progression && n2.locations.progression) {
+          return n1.locations.progression - n2.locations.progression;
+        } else {
+          return undefined;
+        }
+      });
+      return annotations;
+    }
+    return [];
+  }
+
   public getAnnotationPosition(id: any, iframeWin): any {
     const savedAnnotations = this.store.get(LocalAnnotator.ANNOTATIONS);
     if (savedAnnotations) {


### PR DESCRIPTION
When a user navigates to another chapter, both navigate and handleIFrameLoad are being called. There is some overlap between the two functions and e.g. the annotations are being drawn multiple times. Some of those happens too early.

This PR makes it so that navigating between chapters only redraws the annotations once and allows to specifically skip redrawing of annotations when the book view is updated (only relevant for handleIFrameLoad for now).