### PR TITLE
move code that converts lrp href to fully-qualified to before comparison with lastInHistory href

### DIFF
--- a/src/modules/history/HistoryModule.ts
+++ b/src/modules/history/HistoryModule.ts
@@ -137,16 +137,16 @@ export class HistoryModule implements ReaderModule {
           this.history = this.history.slice(0, this.historyCurrentIndex);
         }
         lastInHistory = this.history[this.history.length - 1];
+        const linkHref = this.publication.getAbsoluteHref(
+          lastReadingPosition.href
+        );
+        log.log(lastReadingPosition.href);
+        log.log(linkHref);
+        lastReadingPosition.href = linkHref;
         if (
           (lastInHistory && lastInHistory.href !== lastReadingPosition.href) ||
           lastInHistory === undefined
         ) {
-          const linkHref = this.publication.getAbsoluteHref(
-            lastReadingPosition.href
-          );
-          log.log(lastReadingPosition.href);
-          log.log(linkHref);
-          lastReadingPosition.href = linkHref;
 
           this.history.push(lastReadingPosition);
           this.historyCurrentIndex = this.history.length - 1;

--- a/src/modules/history/HistoryModule.ts
+++ b/src/modules/history/HistoryModule.ts
@@ -102,12 +102,10 @@ export class HistoryModule implements ReaderModule {
           " disabled",
           ""
         );
-        this.historyForwardAnchorElement.hidden = false;
       } else {
         if (this.historyForwardAnchorElement) {
           this.historyForwardAnchorElement.removeAttribute("href");
           this.historyForwardAnchorElement.className += " disabled";
-          this.historyForwardAnchorElement.hidden = true;
         }
       }
       if (this.historyBackAnchorElement && this.historyCurrentIndex > 0) {
@@ -115,12 +113,10 @@ export class HistoryModule implements ReaderModule {
           " disabled",
           ""
         );
-        this.historyBackAnchorElement.hidden = false;
       } else {
         if (this.historyBackAnchorElement) {
           this.historyBackAnchorElement.removeAttribute("href");
           this.historyBackAnchorElement.className += " disabled";
-          this.historyBackAnchorElement.hidden = true;
         }
       }
     }

--- a/src/modules/history/HistoryModule.ts
+++ b/src/modules/history/HistoryModule.ts
@@ -102,10 +102,12 @@ export class HistoryModule implements ReaderModule {
           " disabled",
           ""
         );
+        this.historyForwardAnchorElement.hidden = false;
       } else {
         if (this.historyForwardAnchorElement) {
           this.historyForwardAnchorElement.removeAttribute("href");
           this.historyForwardAnchorElement.className += " disabled";
+          this.historyForwardAnchorElement.hidden = true;
         }
       }
       if (this.historyBackAnchorElement && this.historyCurrentIndex > 0) {
@@ -113,10 +115,12 @@ export class HistoryModule implements ReaderModule {
           " disabled",
           ""
         );
+        this.historyBackAnchorElement.hidden = false;
       } else {
         if (this.historyBackAnchorElement) {
           this.historyBackAnchorElement.removeAttribute("href");
           this.historyBackAnchorElement.className += " disabled";
+          this.historyBackAnchorElement.hidden = true;
         }
       }
     }
@@ -128,26 +132,20 @@ export class HistoryModule implements ReaderModule {
       let lastReadingPosition = (await this.annotator.getLastReadingPosition()) as
         | ReadingPosition
         | undefined;
-      if (
-        lastReadingPosition &&
-        lastReadingPosition?.locations.progression &&
-        lastReadingPosition?.locations.progression > 0
-      ) {
-        if (this.historyCurrentIndex < this.history.length - 1) {
-          this.history = this.history.slice(0, this.historyCurrentIndex);
-        }
-        lastInHistory = this.history[this.history.length - 1];
+      if (lastReadingPosition) {
         const linkHref = this.publication.getAbsoluteHref(
           lastReadingPosition.href
         );
-        log.log(lastReadingPosition.href);
-        log.log(linkHref);
         lastReadingPosition.href = linkHref;
-        if (
-          (lastInHistory && lastInHistory.href !== lastReadingPosition.href) ||
-          lastInHistory === undefined
-        ) {
 
+        if (this.historyCurrentIndex < this.history.length - 1) {
+          this.history = this.history.slice(0, this.historyCurrentIndex);
+          this.history.push(lastReadingPosition);
+          this.historyCurrentIndex = this.history.length - 1;
+        } else if (
+          lastReadingPosition?.locations.progression &&
+          lastReadingPosition?.locations.progression > 0
+        ) {
           this.history.push(lastReadingPosition);
           this.historyCurrentIndex = this.history.length - 1;
         }


### PR DESCRIPTION
The bug happens in the HistoryModule when the lastReadingPosition progression is something greater than 0 and the lastReadingPosition href is compared with the lastInHistory href.  In the bug scenario, two entries are added to the history array -which I believe is unintended.

There are two places in the HistoryModule where items can be added to the history array: line 151 (PUSH 1) and line 164 (PUSH 2). Both PUSHs are called when the progression of the LRP is greater than 0 and the href of the LRP is not equal to the lastInHistory href.  Unfortunately the LRP href is based on tocItem (which is a relative path from the manifest) while lastInHistory href is always fully-qualified because PUSH 1 converts it before pushing and PUSH 2 is based on the locator param passed in from IFrameNavigator. Because of this there are scenarios where both PUSH 1 and PUSH 2 can add entries to the history array when, I believe, only one or the other is intended to.   

NOTE: The bug occurs when the progression of the LRP is greater than 0 -so you have to scroll down slightly in scrolling mode or go to the next chapter page in paginated.   

The fix is to move the code that converts the LRP href value to fully-qualified to before the comparison. In my testing so far (in three browsers) this seems to work well.  