### PR TITLE
Add clearing of timer interval to endResearchSession function

### DIFF
--- a/src/modules/consumption/ConsumptionModule.ts
+++ b/src/modules/consumption/ConsumptionModule.ts
@@ -210,6 +210,7 @@ export class ConsumptionModule implements ReaderModule {
       this.readingSessions = [];
       this.startResearchTimer = undefined;
       clearInterval(this.readingSessionsInterval);
+      clearInterval(this.timer);
     }
   }
 


### PR DESCRIPTION
We frequently get the following error:
`TypeError: Cannot read properties of undefined (reading 'getTime')`
after demounting the iframe of R2D2BC.

This is related to the idle timers interval function not being cleared when ending a research session. 

This PR fixes that.
 