### PR TITLE
Allow start and update of research session in idle timer start

### DIFF
--- a/src/modules/consumption/ConsumptionModule.ts
+++ b/src/modules/consumption/ConsumptionModule.ts
@@ -223,7 +223,11 @@ export class ConsumptionModule implements ReaderModule {
 
     if (this.currSeconds === this.properties.idleTimeout) {
       this.api?.idleSince(this.currSeconds);
-      this.updateResearchSession();
+      if (this.startResearchTimer !== undefined) {
+        this.updateResearchSession();
+      } else {
+        this.startResearchSession();
+      }
     }
     if (
       this.currSeconds ===


### PR DESCRIPTION
When a user idles long enough, an ongoing research session is ended and startResearchTimer set to undefined. When a user then starts to interact with the page again, the timer is reset and the idle timer is started again. 

However, the idle timer tries to update the research session, without checking if one needs to be started first. This PR fixes that, by checking if one is running and if not, starting a new one. 

Steps to reproduce:
- Set idleTimeout and responseTimeout to 1 (just to get the error quicker)
- Open an epub and let it run into endResearchSession by idle timeout
- Interact with the page e.g. by moving the cursor across the epub

Screenshot from dita example:
![image](https://github.com/d-i-t-a/R2D2BC/assets/29171805/f4c26146-ca03-499f-a7c7-1a696e365888)
