### PR TITLE
Show toolbox on selection change 

### DIFF
--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -645,6 +645,7 @@ export class TextHighlighter {
       window.addEventListener("resize", this.toolboxPlacement.bind(this));
     }
     doc.addEventListener("selectionchange", this.toolboxPlacement.bind(this));
+    doc.addEventListener("selectionchange", this.toolboxShowDelayed.bind(this));
 
     el.addEventListener("mousedown", this.toolboxHide.bind(this));
     el.addEventListener("touchstart", this.toolboxHide.bind(this));


### PR DESCRIPTION
When selecting multiple words, the toolbox does not show up on android mobile. This fixes it, by opening it on a selectionchange event. 