### PR TITLE
Get clear text content for search in obfuscated text

### DIFF
--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -1493,4 +1493,20 @@ export class ContentProtectionModule implements ReaderModule {
     }
     return paragraph ? scramble(words).join(" ") : words.join(" ");
   }
+
+  public getUnscrambledDoc(): Document | null {
+    if (this.navigator.iframes[0].contentDocument) {
+      let unscrambledDoc = this.navigator.iframes[0].contentDocument.cloneNode(
+        true
+      ) as Document;
+      let newRects = this.findRects(unscrambledDoc.body);
+
+      this.rects.forEach((rect, index) => {
+        newRects[index].node.textContent = rect.textContent;
+      });
+      return unscrambledDoc;
+    }
+
+    return null;
+  }
 }

--- a/src/modules/search/SearchModule.ts
+++ b/src/modules/search/SearchModule.ts
@@ -310,7 +310,19 @@ export class SearchModule implements ReaderModule {
     }
     let i = 0;
     if (tocItem) {
-      let doc = this.navigator.iframes[0].contentDocument;
+      let doc;
+      if (
+        this.navigator.contentProtectionModule?.properties?.enableObfuscation &&
+        this.navigator.api?.getContent
+      ) {
+        doc = new DOMParser().parseFromString(
+          await this.navigator.api.getContent(linkHref),
+          "text/html"
+        );
+      } else {
+        doc = this.navigator.iframes[0].contentDocument;
+      }
+
       if (doc) {
         if (tocItem) {
           searchDocDomSeek(term, doc, tocItem.Href, tocItem.Title).then(

--- a/src/modules/search/SearchModule.ts
+++ b/src/modules/search/SearchModule.ts
@@ -315,10 +315,7 @@ export class SearchModule implements ReaderModule {
         this.navigator.contentProtectionModule?.properties?.enableObfuscation &&
         this.navigator.api?.getContent
       ) {
-        doc = new DOMParser().parseFromString(
-          await this.navigator.api.getContent(linkHref),
-          "text/html"
-        );
+        doc = this.navigator.contentProtectionModule.getUnscrambledDoc();
       } else {
         doc = this.navigator.iframes[0].contentDocument;
       }


### PR DESCRIPTION
If obfuscation is enabled, the in book text search needs to be able to search within the unscrambled content, otherwise only search results within are added to the search results of the current chapter. 

This PR gets the clear text content using the getContent function provided by the api to get the clear text content.