### PR TITLE
Prevent delayed showing of toolbox on ios

### DIFF
--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -655,7 +655,12 @@ export class TextHighlighter {
       window.addEventListener("resize", this.toolboxPlacement.bind(this));
     }
     doc.addEventListener("selectionchange", this.toolboxPlacement.bind(this));
-    doc.addEventListener("selectionchange", this.toolboxShowDelayed.bind(this));
+    if (!this.isIOS()) {
+      doc.addEventListener(
+        "selectionchange",
+        this.toolboxShowDelayed.bind(this)
+      );
+    }
 
     el.addEventListener("mousedown", this.toolboxHide.bind(this));
     el.addEventListener("touchstart", this.toolboxHide.bind(this));


### PR DESCRIPTION
Toolbox "flickers" on iOS, i.e. opens and continuously reopens again. This only happens on iOS and it seems other platforms are fine with the current way of doing it. 

However, iOS seems to work fine without that particular event handler. 