### PR TITLE
configuration to use a memory store

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -212,6 +212,7 @@ export interface ReaderConfig {
   injectables: Array<Injectable>;
   injectablesFixed?: Array<Injectable>;
   useLocalStorage?: boolean;
+  storageType?: string;
   attributes?: IFrameAttributes;
   services?: PublicationServices;
   sample?: SampleRead;

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -45,6 +45,8 @@ import {
 } from "./navigator/IFrameNavigator";
 import LocalAnnotator from "./store/LocalAnnotator";
 import LocalStorageStore from "./store/LocalStorageStore";
+import Store from "./store/Store";
+import MemoryStore from "./store/MemoryStore";
 import { findElement, findRequiredElement } from "./utils/HTMLUtilities";
 import { convertAndCamel } from "./model/Link";
 import { LayerSettings } from "./modules/highlight/LayerSettings";
@@ -147,19 +149,35 @@ export default class D2Reader {
       );
     }
 
-    const store = new LocalStorageStore({
-      prefix: publication.manifestUrl,
-      useLocalStorage: initialConfig.useLocalStorage ?? false,
-    });
+    let store: Store;
+    if(initialConfig.storageType === 'memory') {
+      store = new MemoryStore();
+    } else {
+      store = new LocalStorageStore({
+        prefix: publication.manifestUrl,
+        useLocalStorage: initialConfig.useLocalStorage ?? false,
+      });
+    }
 
-    const settingsStore = new LocalStorageStore({
-      prefix: "r2d2bc-reader",
-      useLocalStorage: initialConfig.useLocalStorage ?? false,
-    });
-    const layerStore = new LocalStorageStore({
-      prefix: "r2d2bc-layers",
-      useLocalStorage: initialConfig.useLocalStorage ?? false,
-    });
+    let settingsStore: Store;
+    if(initialConfig.storageType === 'memory') {
+      settingsStore = new MemoryStore();
+    } else {
+      settingsStore = new LocalStorageStore({
+        prefix: "r2d2bc-reader",
+        useLocalStorage: initialConfig.useLocalStorage ?? false,
+      });
+    }
+
+    let layerStore: Store;
+    if(initialConfig.storageType === 'memory') {
+      layerStore = new MemoryStore();
+    } else {
+      layerStore = new LocalStorageStore({
+        prefix: "r2d2bc-layers",
+        useLocalStorage: initialConfig.useLocalStorage ?? false,
+      });
+    }
 
     const annotator = new LocalAnnotator({ store: store });
 

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1362,6 +1362,7 @@
             injectablesFixed: [],
             userSettings: userSettings,
             useLocalStorage: true, // true = uses local storage, false = uses session storage (default)
+            storageType: "local", // 'memory' = uses a memory storage, anything else = uses local/session storage (default)
         }).then(instance => {
             console.log("D2reader instance ready", instance);
             d2reader = instance;


### PR DESCRIPTION
Closes: #628

@aferditamuriqi it seems there is already a `Store` interface, and a `MemoryStore`.

The reader exposes a `ReaderConfig.useLocalStorage` configuration, which is passed to the `LocalStorageStore`, and defines whether the store uses `window.localStorage` or `window.sessionStorage` for storage.

This PR adds a new configuration key `ReaderConfig.storageType`. By default this is unset, and will not change the default behaviour, as it would use a `LocalStorageStore`.

If the key is set to `memory`, then a `MemoryStore` is used.

I used a `string` configuration key, so it can be expanded in the future if needed.