### PR TITLE
better appearance handling in initialUserSettings

### DIFF
--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -188,9 +188,7 @@ export class UserSettings implements IUserSettings {
         log.log(settings.verticalScroll);
       }
       if (initialUserSettings.appearance) {
-        settings.appearance = UserSettings.appearanceValues.findIndex(
-          (el: any) => el === initialUserSettings.appearance
-        );
+        settings.appearance = UserSettings.parseAppearanceSetting(initialUserSettings.appearance)
         let prop = settings.userProperties.getByRef(ReadiumCSS.APPEARANCE_REF);
         if (prop) {
           prop.value = settings.appearance;
@@ -989,28 +987,7 @@ export class UserSettings implements IUserSettings {
 
   async applyUserSettings(userSettings: Partial<UserSettings>): Promise<void> {
     if (userSettings.appearance) {
-      let a: string;
-      if (
-        userSettings.appearance === "day" ||
-        userSettings.appearance === "readium-default-on"
-      ) {
-        a = UserSettings.appearanceValues[0];
-      } else if (
-        userSettings.appearance === "sepia" ||
-        userSettings.appearance === "readium-sepia-on"
-      ) {
-        a = UserSettings.appearanceValues[1];
-      } else if (
-        userSettings.appearance === "night" ||
-        userSettings.appearance === "readium-night-on"
-      ) {
-        a = UserSettings.appearanceValues[2];
-      } else {
-        a = userSettings.appearance;
-      }
-      this.appearance = UserSettings.appearanceValues.findIndex(
-        (el: any) => el === a
-      );
+      this.appearance = UserSettings.parseAppearanceSetting(userSettings.appearance)
       let prop = this.userProperties?.getByRef(ReadiumCSS.APPEARANCE_REF);
       if (prop) {
         prop.value = this.appearance;
@@ -1136,6 +1113,33 @@ export class UserSettings implements IUserSettings {
       default:
         return false;
     }
+  }
+
+  private static parseAppearanceSetting(
+    inputSetting: InitialUserSettings["appearance"]
+  ): number {
+    let a: string;
+    if (
+      inputSetting === "day" ||
+      inputSetting === "readium-default-on"
+    ) {
+      a = UserSettings.appearanceValues[0];
+    } else if (
+      inputSetting === "sepia" ||
+      inputSetting === "readium-sepia-on"
+    ) {
+      a = UserSettings.appearanceValues[1];
+    } else if (
+      inputSetting === "night" ||
+      inputSetting === "readium-night-on"
+    ) {
+      a = UserSettings.appearanceValues[2];
+    } else {
+      a = inputSetting;
+    }
+    return UserSettings.appearanceValues.findIndex(
+      (el: any) => el === a
+    );
   }
 
   async scroll(scroll: boolean): Promise<void> {

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -765,7 +765,7 @@
             },
         ]
         let userSettings = {
-            // appearance: "readium-sepia-on", //readium-default-on, readium-night-on, readium-sepia-on
+            // appearance: "sepia", //readium-default-on, day, readium-night-on, night, readium-sepia-on, sepia
             // fontFamily: "serif", //Original, serif, sans-serif
             // textAlignment: "start", //"auto", "justify", "start"
             // columnCount: "1", // "auto", "1", "2"


### PR DESCRIPTION
Currently the `appearance` in the initial `userSettings` only accepts `readium-default-on`, `readium-night-on` and `readium-sepia-on`, while `applyUserSettings` also accepts `day`, `night` and `sepia`.

This PR pulls the existing logic from `applyUserSettings` into a function `parseAppearanceSetting`, and reuses that logic in `UserSettings.create()`.