### PR TITLE
prefix css classes, use ID selectors when possible

### DIFF
--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -65,7 +65,7 @@ const App = () => {
             }}
           >
             <div id="reader-loading" className="loading"></div>
-            <div id="reader-error" className="error"></div>
+            <div id="reader-error"></div>
           </main>
         </div>
       </div>

--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -64,7 +64,7 @@ const App = () => {
               height: "calc(100vh - 10px)",
             }}
           >
-            <div id="reader-loading" className="loading"></div>
+            <div id="reader-loading"></div>
             <div id="reader-error"></div>
           </main>
         </div>

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -645,15 +645,14 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
       );
       this.goBackButton = HTMLUtilities.findElement(
         mainElement,
-      this.infoTop = HTMLUtilities.findElement(
-        mainElement,
-        "div[class='info top']"
         "#r2d2bc-go-back"
       );
-      this.infoBottom = HTMLUtilities.findElement(
-        mainElement,
-        "div[class='info bottom']"
-      );
+      this.infoTop =
+        HTMLUtilities.findElement(mainElement, "#reader-info-top") ||
+        HTMLUtilities.findElement(mainElement, "div[class='info top']");
+      this.infoBottom =
+        HTMLUtilities.findElement(mainElement, "#reader-info-bottom") ||
+        HTMLUtilities.findElement(mainElement, "div[class='info bottom']");
 
       if (this.headerMenu)
         this.bookTitle = HTMLUtilities.findElement(

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -641,15 +641,14 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
       this.tryAgainButton = HTMLUtilities.findElement(
         mainElement,
-        "button[class=try-again]"
+        "#r2d2bc-try-again"
       );
       this.goBackButton = HTMLUtilities.findElement(
         mainElement,
-        "button[class=go-back]"
-      );
       this.infoTop = HTMLUtilities.findElement(
         mainElement,
         "div[class='info top']"
+        "#r2d2bc-go-back"
       );
       this.infoBottom = HTMLUtilities.findElement(
         mainElement,

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -662,20 +662,26 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         );
 
       if (this.infoBottom)
-        this.chapterTitle = HTMLUtilities.findElement(
-          this.infoBottom,
-          "span[class=chapter-title]"
-        );
+        this.chapterTitle =
+          HTMLUtilities.findElement(this.infoBottom, "#chapter-title") ||
+          HTMLUtilities.findElement(
+            this.infoBottom,
+            "span[class=chapter-title]"
+          );
       if (this.infoBottom)
-        this.chapterPosition = HTMLUtilities.findElement(
-          this.infoBottom,
-          "span[class=chapter-position]"
-        );
+        this.chapterPosition =
+          HTMLUtilities.findElement(this.infoBottom, "#chapter-position") ||
+          HTMLUtilities.findElement(
+            this.infoBottom,
+            "span[class=chapter-position]"
+          );
       if (this.infoBottom)
-        this.remainingPositions = HTMLUtilities.findElement(
-          this.infoBottom,
-          "span[class=remaining-positions]"
-        );
+        this.remainingPositions =
+          HTMLUtilities.findElement(this.infoBottom, "#remaining-positions") ||
+          HTMLUtilities.findElement(
+            this.infoBottom,
+            "span[class=remaining-positions]"
+          );
 
       if (this.headerMenu)
         this.espandMenuIcon = HTMLUtilities.findElement(

--- a/src/navigator/PDFNavigator.ts
+++ b/src/navigator/PDFNavigator.ts
@@ -110,7 +110,7 @@ export class PDFNavigator extends EventEmitter implements Navigator {
     loadingMessage.style.alignItems = "center";
     loadingMessage.style.justifyContent = "center";
     loadingMessage.style.background = "white";
-    loadingMessage.className = "loading is-loading";
+    loadingMessage.className = "r2d2bc-loading is-loading";
 
     this.pdfContainer.appendChild(loadingMessage);
 

--- a/src/styles/sass/reader/_error.scss
+++ b/src/styles/sass/reader/_error.scss
@@ -17,7 +17,8 @@
  * Licensed to: Bokbasen AS and CAST under one or more contributor license agreements.
  */
 
-.error {
+#reader-error,
+.r2d2bc-error {
   position: sticky;
   z-index: 20;
   background-color: transparentize($ui-white, 0.125);
@@ -65,7 +66,8 @@
 
 
 [data-viewer-theme="sepia"] {
-  .error {
+  #reader-error,
+  .r2d2bc-error {
     background-color: transparentize($sepia-bg, 0.125);
 
     button {
@@ -77,7 +79,8 @@
 }
 
 [data-viewer-theme="night"] {
-  .error {
+  #reader-error,
+  .r2d2bc-error {
     background-color: transparentize($night-bg, 0.125);
 
     button {

--- a/src/styles/sass/reader/_global.scss
+++ b/src/styles/sass/reader/_global.scss
@@ -73,8 +73,12 @@
     bottom: 0px;
     position: fixed;
     width: 100%;
+    @extend .r2d2bc-info, .r2d2bc-bottom;
   }
-  .info {
+  #reader-info-top {
+    @extend .r2d2bc-info, .r2d2bc-top;
+  }
+  .r2d2bc-info {
     color: $ui-dark-gray;
     margin: 0;
     padding: 0 1.5rem;
@@ -89,13 +93,13 @@
     user-select: none;
     cursor: default;
 
-    &.top {
+    &.r2d2bc-top {
       line-height: 3;
       padding-top: env(safe-area-inset-top);
       min-height: 3.6rem;
     }
 
-    &.bottom {
+    &.r2d2bc-bottom {
       line-height: 2;
       padding-bottom: env(safe-area-inset-bottom);
     }
@@ -126,7 +130,7 @@
 
 
 
-    .info {
+    .r2d2bc-info {
       color: $ui-dark-gray;
     }
 
@@ -138,7 +142,7 @@
 
 
 
-    .info {
+    .r2d2bc-info {
       color: $ui-light-gray;
     }
 

--- a/src/styles/sass/reader/_global.scss
+++ b/src/styles/sass/reader/_global.scss
@@ -100,6 +100,9 @@
       padding-bottom: env(safe-area-inset-bottom);
     }
 
+    #chapter-position,
+    #chapter-title,
+    #remaining-positions,
     .chapter-position,
     .chapter-title,
     .remaining-positions {

--- a/src/styles/sass/reader/_loading.scss
+++ b/src/styles/sass/reader/_loading.scss
@@ -37,13 +37,15 @@
   }
 }
 
-.loading.is-loading {
+#reader-loading.is-loading,
+.r2d2bc-loading.is-loading {
   .icon {
     animation: load 1s ease-in-out infinite;
   }
 }
 
-.loading {
+#reader-loading,
+.r2d2bc-loading {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -69,13 +71,15 @@
 }
 
 [data-viewer-theme="sepia"] {
-  .loading {
+  #reader-loading,
+  .r2d2bc-loading {
     background-color: transparentize($sepia-bg, 0.1);
   }
 }
 
 [data-viewer-theme="night"] {
-  .loading {
+  #reader-loading,
+  .r2d2bc-loading {
     background-color: lighten($night-bg, 10%);
     color: $ui-light-gray;
 

--- a/src/styles/sass/reader/_tts.scss
+++ b/src/styles/sass/reader/_tts.scss
@@ -31,14 +31,14 @@ $brand: rgb(16, 16, 16);;
 
 
 
-input[type=checkbox] label {
+.r2d2bc-tts-checkbox label {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
 
-input[type=checkbox] {
+.r2d2bc-tts-checkbox {
   position: relative !important;
   appearance: none;
 //   margin: $margin-small;

--- a/src/utils/HTMLTemplates.ts
+++ b/src/utils/HTMLTemplates.ts
@@ -25,6 +25,6 @@ export const readerError = `
     ${IconLib.icons.error}
     </span>
     <span>There was an error loading this page.</span>
-    <button class="go-back">Go back</button>
-    <button class="try-again">Try again</button>
+    <button id="r2d2bc-go-back">Go back</button>
+    <button id="r2d2bc-try-again">Try again</button>
 `;

--- a/viewer/index_api.html
+++ b/viewer/index_api.html
@@ -375,7 +375,7 @@
                 <div id="lineFocusBottomBlinder" class="d2-line-focus-bottom"></div>
             </div>
             <main style="height: calc(100vh - 10px)" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-loading" class="loading"></div>
+                <div id="reader-loading"></div>
                 <div id="reader-error"></div>
                 <div style="height: 0px">
                 <span id="highlight-toolbox" class="highlight-toolbox">

--- a/viewer/index_api.html
+++ b/viewer/index_api.html
@@ -376,7 +376,7 @@
             </div>
             <main style="height: calc(100vh - 10px)" tabindex=-1 id="iframe-wrapper">
                 <div id="reader-loading" class="loading"></div>
-                <div id="reader-error" class="error"></div>
+                <div id="reader-error"></div>
                 <div style="height: 0px">
                 <span id="highlight-toolbox" class="highlight-toolbox">
                     <div id="highlight-toolbox-mode-add">

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -626,8 +626,8 @@
                 <div id="lineFocusBottomBlinder" class="d2-line-focus-bottom"></div>
             </div>
             <main style="height: calc(100vh - 65px);" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-loading" class="loading"></div>
                 <div id="reader-info-top" class="info top">
+                <div id="reader-loading"></div>
                 <div id="reader-error"></div>
                     <span class="book-title"></span>
                 </div>

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -626,12 +626,12 @@
                 <div id="lineFocusBottomBlinder" class="d2-line-focus-bottom"></div>
             </div>
             <main style="height: calc(100vh - 65px);" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-info-top" class="info top">
                 <div id="reader-loading"></div>
                 <div id="reader-error"></div>
+                <div id="reader-info-top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="info bottom">
+                <div id="reader-info-bottom">
                     <div style="display: flex;justify-content: center;">
                         <span id="chapter-position"></span>&nbsp;
                         <span id="chapter-title"></span>

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -627,8 +627,8 @@
             </div>
             <main style="height: calc(100vh - 65px);" tabindex=-1 id="iframe-wrapper">
                 <div id="reader-loading" class="loading"></div>
-                <div id="reader-error" class="error"></div>
                 <div id="reader-info-top" class="info top">
+                <div id="reader-error"></div>
                     <span class="book-title"></span>
                 </div>
                 <div id="reader-info-bottom" class="info bottom">

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -132,7 +132,7 @@
                     <div style="padding: 5px;">
                         <center style="display: flex;justify-content: center;align-items: center;">
                             <label style="margin-right: 10px;">Auto Scroll</label>
-                            <input type="checkbox" class="filled" id="autoScroll" name="autoScroll"
+                            <input type="checkbox" class="filled r2d2bc-tts-checkbox" id="autoScroll" name="autoScroll"
                                    onchange="d2reader.applyTTSSettings({ autoScroll: this.checked })">
                         </center>
                     </div>

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -633,8 +633,8 @@
                 </div>
                 <div id="reader-info-bottom" class="info bottom">
                     <div style="display: flex;justify-content: center;">
-                        <span class="chapter-position"></span>&nbsp;
-                        <span class="chapter-title"></span>
+                        <span id="chapter-position"></span>&nbsp;
+                        <span id="chapter-title"></span>
                     </div>
                     <div class="scrubber">
                         <input class="range-slider__range" style="margin-left:30px;display: none" type="range" min="1" step="1" id="positionSlider" name="positionSlider" onchange="d2reader.goToPosition( this.value )" />

--- a/viewer/index_minimal.html
+++ b/viewer/index_minimal.html
@@ -50,7 +50,7 @@
         <div id="D2Reader-Container" style="border: solid 5px rebeccapurple">
             <main style="height: calc(100vh - 10px)" tabindex=-1 id="iframe-wrapper">
                 <div id="reader-loading" class="loading"></div>
-                <div id="reader-error" class="error"></div>
+                <div id="reader-error"></div>
             </main>
         </div>
     </div>

--- a/viewer/index_minimal.html
+++ b/viewer/index_minimal.html
@@ -49,7 +49,7 @@
     <div class="content" id="root">
         <div id="D2Reader-Container" style="border: solid 5px rebeccapurple">
             <main style="height: calc(100vh - 10px)" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-loading" class="loading"></div>
+                <div id="reader-loading"></div>
                 <div id="reader-error"></div>
             </main>
         </div>

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -173,8 +173,8 @@
         <div id="D2Reader-Container" style="border: solid 5px rebeccapurple;">
             <main style="height: calc(100vh - 75px)" tabindex=-1 id="iframe-wrapper">
                 <div id="reader-loading" class="loading"></div>
-                <div id="reader-error" class="error"></div>
                 <div id="reader-info-top" class="info top">
+                <div id="reader-error"></div>
                     <span class="book-title"></span>
                 </div>
                 <div id="reader-info-bottom" class="info bottom">

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -172,12 +172,12 @@
 
         <div id="D2Reader-Container" style="border: solid 5px rebeccapurple;">
             <main style="height: calc(100vh - 75px)" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-info-top" class="info top">
                 <div id="reader-loading"></div>
                 <div id="reader-error"></div>
+                <div id="reader-info-top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="info bottom">
+                <div id="reader-info-bottom">
                     <div style="display: flex;justify-content: center;">
                         <span id="chapter-position"></span>&nbsp;
                         <span id="chapter-title"></span>

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -172,8 +172,8 @@
 
         <div id="D2Reader-Container" style="border: solid 5px rebeccapurple;">
             <main style="height: calc(100vh - 75px)" tabindex=-1 id="iframe-wrapper">
-                <div id="reader-loading" class="loading"></div>
                 <div id="reader-info-top" class="info top">
+                <div id="reader-loading"></div>
                 <div id="reader-error"></div>
                     <span class="book-title"></span>
                 </div>

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -179,14 +179,14 @@
                 </div>
                 <div id="reader-info-bottom" class="info bottom">
                     <div style="display: flex;justify-content: center;">
-                        <span class="chapter-position"></span>&nbsp;
-                        <span class="chapter-title"></span>
+                        <span id="chapter-position"></span>&nbsp;
+                        <span id="chapter-title"></span>
                     </div>
                     <div class="scrubber">
                         <input class="range-slider__range" style="width:100%" type="range" min="1" step="1" id="positionSlider" name="positionSlider" onchange="d2reader.goToPosition( this.value )" />
                     </div>
                     <div>
-                        <span class="remaining-positions"></span>
+                        <span id="remaining-positions"></span>
                     </div>
                 </div>
             </main>


### PR DESCRIPTION
This PR addresses #641 by prefixing some CSS classes with `r2d2bc-`.

It also removes some of the logic to find HTML elements by CSS classes, and instead uses ID selectors.

Closes #641