### PR TITLE
Feature: event fallthrough for keydown and click

### DIFF
--- a/src/modules/search/Popup.ts
+++ b/src/modules/search/Popup.ts
@@ -151,16 +151,21 @@ export class Popup {
           return;
         }
         let self = this;
-        win.onclick = function (ev) {
-          if (event.target !== ev.target) {
-            if (d2popover.parentElement) {
-              self.hidePopover();
-              if (win) {
-                win.onclick = null;
+        win.addEventListener(
+          "click",
+          function (ev) {
+            if (event.target !== ev.target) {
+              if (d2popover.parentElement) {
+                self.hidePopover();
+                ev.stopImmediatePropagation();
               }
             }
+          },
+          {
+            once: true,
+            capture: true,
           }
-        };
+        );
       }
     } else if (src) {
       let absolute = getAbsoluteHref(src);
@@ -207,16 +212,21 @@ export class Popup {
           return;
         }
         let self = this;
-        win.onclick = function (ev) {
-          if (event.target !== ev.target) {
-            if (d2popover.parentElement) {
-              self.hidePopover();
-              if (win) {
-                win.onclick = null;
+        win.addEventListener(
+          "click",
+          function (ev) {
+            if (event.target !== ev.target) {
+              if (d2popover.parentElement) {
+                self.hidePopover();
+                ev.stopImmediatePropagation();
               }
             }
+          },
+          {
+            once: true,
+            capture: true,
           }
-        };
+        );
       }
     }
   }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -97,6 +97,7 @@ import {
   ConsumptionModule,
   ConsumptionModuleConfig,
 } from "../modules/consumption/ConsumptionModule";
+import KeyDownEvent = JQuery.KeyDownEvent;
 
 export type GetContent = (href: string) => Promise<string>;
 export type GetContentBytesLength = (
@@ -117,6 +118,7 @@ export interface NavigatorAPI {
   resourceAtEnd: any;
   resourceFitsScreen: any;
   updateCurrentLocation: any;
+  keydownFallthrough: any;
   direction: any;
   onError?: (e: Error) => void;
 }
@@ -1004,6 +1006,8 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           this.handlePreviousChapterClick.bind(this);
         this.keyboardEventHandler.onForwardSwipe =
           this.handleNextChapterClick.bind(this);
+        this.keyboardEventHandler.onKeydown =
+          this.handleKeydownFallthrough.bind(this);
       }
       if (this.touchEventHandler) {
         this.touchEventHandler.onBackwardSwipe =
@@ -1048,6 +1052,8 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               this.handlePreviousPageClick.bind(this);
             this.keyboardEventHandler.onForwardSwipe =
               this.handleNextPageClick.bind(this);
+            this.keyboardEventHandler.onKeydown =
+              this.handleKeydownFallthrough.bind(this);
           }
         } else {
           if (this.infoBottom) this.infoBottom.style.display = "none";
@@ -1168,6 +1174,8 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               this.handlePreviousPageClick.bind(this);
             this.keyboardEventHandler.onForwardSwipe =
               this.handleNextPageClick.bind(this);
+            this.keyboardEventHandler.onKeydown =
+              this.handleKeydownFallthrough.bind(this);
           }
         }
       });
@@ -2813,6 +2821,11 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
       event.preventDefault();
       event.stopPropagation();
     }
+  }
+
+  private handleKeydownFallthrough(event: KeyDownEvent | undefined): void {
+    if (this.api?.keydownFallthrough) this.api?.keydownFallthrough(event);
+    this.emit("keydown", event);
   }
 
   private hideView(): void {

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1708,8 +1708,8 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         e instanceof Error
           ? e
           : typeof e === "string"
-            ? new Error(e)
-            : new Error("An unknown error occurred in the IFrameNavigator.");
+          ? new Error(e)
+          : new Error("An unknown error occurred in the IFrameNavigator.");
       this.api.onError(trueError);
     } else {
       // otherwise just display the standard error UI

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1002,6 +1002,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         this.nextChapterBottomAnchorElement.style.display = "none";
       if (this.previousChapterTopAnchorElement)
         this.previousChapterTopAnchorElement.style.display = "none";
+      if (this.eventHandler) {
+        this.eventHandler.onClickThrough = this.handleClickThrough.bind(this);
+      }
       if (this.keyboardEventHandler) {
         this.keyboardEventHandler.onBackwardSwipe =
           this.handlePreviousChapterClick.bind(this);

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -119,6 +119,7 @@ export interface NavigatorAPI {
   resourceFitsScreen: any;
   updateCurrentLocation: any;
   keydownFallthrough: any;
+  clickThrough: any;
   direction: any;
   onError?: (e: Error) => void;
 }
@@ -2491,7 +2492,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
     }
   }
 
-  private handleClickThrough(_event: MouseEvent | TouchEvent) {}
+  private handleClickThrough(event: MouseEvent | TouchEvent) {
+    if (this.api?.clickThrough) this.api?.clickThrough(event);
+    this.emit("click", event);
+  }
 
   private handleInternalLink(event: MouseEvent | TouchEvent) {
     const element = event.target;

--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -68,7 +68,7 @@ export default class EventHandler {
       // Most click handling is done in the touchend and mouseup event handlers,
       // but if there's a click on an external link we need to cancel the click
       // event to prevent it from opening in the iframe.
-      element.addEventListener("click", this.handleLinks.bind(this));
+      element.addEventListener("click", this.handleLinks.bind(this), true);
     } else {
       throw "cannot setup events for null";
     }

--- a/src/utils/KeyboardEventHandler.ts
+++ b/src/utils/KeyboardEventHandler.ts
@@ -29,6 +29,7 @@ export default class KeyboardEventHandler {
 
   public onBackwardSwipe: (event: UIEvent) => void = () => {};
   public onForwardSwipe: (event: UIEvent) => void = () => {};
+  public onKeydown: (event: UIEvent) => void = () => {};
 
   public setupEvents = (element: HTMLElement | Document | null): void => {
     if (element) {
@@ -93,20 +94,22 @@ export default class KeyboardEventHandler {
         switch (key) {
           case "ArrowRight":
             self.rtl ? self.onBackwardSwipe(event) : self.onForwardSwipe(event);
-            break;
+            return;
           case "ArrowLeft":
             self.rtl ? self.onForwardSwipe(event) : self.onBackwardSwipe(event);
-            break;
-        }
-        switch (event.code) {
-          case "Space":
-            if (event.ctrlKey) {
-              self.onBackwardSwipe(event);
-            } else {
-              self.onForwardSwipe(event);
-            }
-            break;
-        }
+            return;
+          }
+          switch (event.code) {
+            case "Space":
+              if (event.ctrlKey) {
+                self.onBackwardSwipe(event);
+                return;
+              } else {
+                self.onForwardSwipe(event);
+                return;
+              }
+          }
+        self.onKeydown(event);
       })
     );
   }

--- a/src/utils/KeyboardEventHandler.ts
+++ b/src/utils/KeyboardEventHandler.ts
@@ -98,17 +98,17 @@ export default class KeyboardEventHandler {
           case "ArrowLeft":
             self.rtl ? self.onForwardSwipe(event) : self.onBackwardSwipe(event);
             return;
-          }
-          switch (event.code) {
-            case "Space":
-              if (event.ctrlKey) {
-                self.onBackwardSwipe(event);
-                return;
-              } else {
-                self.onForwardSwipe(event);
-                return;
-              }
-          }
+        }
+        switch (event.code) {
+          case "Space":
+            if (event.ctrlKey) {
+              self.onBackwardSwipe(event);
+              return;
+            } else {
+              self.onForwardSwipe(event);
+              return;
+            }
+        }
         self.onKeydown(event);
       })
     );

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1405,6 +1405,9 @@
                 keydownFallthrough: function(event) {
                     console.log("api.keydownFallthrough:" + event.key);
                 },
+                clickThrough: function(event) {
+                    console.log("api.clickThrough");
+                },
                 onError: function(error) {
                     console.log(error);
                 },
@@ -1454,6 +1457,9 @@
             });
             instance.addEventListener("keydown", (event) => {
                 console.log("keydown: " + event.key);
+            });
+            instance.addEventListener("click", (event) => {
+                console.log("click through: " + event.detail);
             });
 
         }).catch(error => {

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1402,6 +1402,9 @@
                         );
                     });
                 },
+                keydownFallthrough: function(event) {
+                    console.log("api.keydownFallthrough:" + event.key);
+                },
                 onError: function(error) {
                     console.log(error);
                 },
@@ -1448,6 +1451,9 @@
             });
             instance.addEventListener("resource.ready", () => {
                 console.log("listener ready");
+            });
+            instance.addEventListener("keydown", (event) => {
+                console.log("keydown: " + event.key);
             });
 
         }).catch(error => {


### PR DESCRIPTION
This PR addresses #627

As mentioned in [my last comment](https://github.com/d-i-t-a/R2D2BC/issues/627#issuecomment-1820555473) on the above issue, event bubbling from an iframe to the container does not work in Javascript, thus injectables do not solve the problem at hand.

Since the `IFrameNavigator` is handling the iframes themselves, and can be configured by the upper component, it makes sense that it allows for event redirection.

The `clickThrough` functions were already there, but not exposed. I added a new API field for this, and i had to change a few things to correctly handle the popup clicks, so that the events are not sent in the `clickThrough` API if they already had an effect in the iFrame. For instance when clicking to reduce the image/footnote popup, the click event will not be falling through.

I implemented something similar for keyboard events, where any keydown event that was not being handled in the Navigator will be falling through to the containing component.

IMHO this is an elegant solution, which allows for out of the box customization without having to resort to injectables.