### PR TITLE
fix: properly unregister keydown event on top-level document on stop

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -523,6 +523,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
     this.iframes.forEach((iframe) => {
       removeEventListenerOptional(iframe, "resize", this.onResize);
     });
+
+    if (this.didInitKeyboardEventHandler)
+      this.keyboardEventHandler.removeEvents(document);
   }
   spreads: HTMLDivElement;
   firstSpread: HTMLDivElement;


### PR DESCRIPTION
The `IFrameNavigator` registers the keyboard events on the top-level `document`, in addition to register them on each of the iframe document on iframe load.

The top-level event is never de-registered though.

This PR deregisters the top-level event when calling `.stop()` on the navigator.

In order to deregister the event, i added a `handlers` property to store the generated dynamic functions, else the calls to `removeEventListener` would not work.

This PR kinda conflicts with #681 - I can rework this one if #681 gets merged first