### PR TITLE
fix: data-viewer-theme attribute would leak at top level document

### DIFF
--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -413,8 +413,10 @@ export class UserSettings implements IUserSettings {
         "html"
       ) as HTMLHtmlElement;
       if (html) {
-        const rootElement = document.documentElement;
-        const body = HTMLUtilities.findRequiredElement(rootElement, "body");
+        const rootElement =
+          HTMLUtilities.findElement(document, "#root") ||
+          document.documentElement;
+        const body = HTMLUtilities.findElement(html, "body");
 
         // // Apply publishers default
         // html.style.removeProperty(ReadiumCSS.PUBLISHER_DEFAULT_KEY);
@@ -435,8 +437,9 @@ export class UserSettings implements IUserSettings {
 
         // Apply appearance
         html.style.removeProperty(ReadiumCSS.APPEARANCE_KEY);
-        HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
-        HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
+        if (rootElement)
+          HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
+        if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
 
         // Apply font family
         html.style.removeProperty(ReadiumCSS.FONT_FAMILY_KEY);
@@ -468,8 +471,10 @@ export class UserSettings implements IUserSettings {
       ) as HTMLHtmlElement;
 
       if (html) {
-        const rootElement = document.documentElement;
-        const body = HTMLUtilities.findRequiredElement(rootElement, "body");
+        const rootElement =
+          HTMLUtilities.findElement(document, "#root") ||
+          document.documentElement;
+        const body = HTMLUtilities.findElement(html, "body");
         if (this.view?.navigator.publication.isReflowable) {
           // Apply font size
           if (await this.getProperty(ReadiumCSS.FONT_SIZE_KEY)) {
@@ -578,18 +583,21 @@ export class UserSettings implements IUserSettings {
           if (
             this.userProperties.getByRef(ReadiumCSS.APPEARANCE_REF)?.value === 0
           ) {
-            HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
-            HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
+            if (rootElement)
+              HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
+            if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
           } else if (
             this.userProperties.getByRef(ReadiumCSS.APPEARANCE_REF)?.value === 1
           ) {
-            HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "sepia");
-            HTMLUtilities.setAttr(body, "data-viewer-theme", "sepia");
+            if (rootElement)
+              HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "sepia");
+            if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "sepia");
           } else if (
             this.userProperties.getByRef(ReadiumCSS.APPEARANCE_REF)?.value === 2
           ) {
-            HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "night");
-            HTMLUtilities.setAttr(body, "data-viewer-theme", "night");
+            if (rootElement)
+              HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "night");
+            if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "night");
           }
         } else {
           html.style.setProperty(
@@ -598,8 +606,9 @@ export class UserSettings implements IUserSettings {
               .getByRef(ReadiumCSS.APPEARANCE_REF)
               ?.toString() ?? null
           );
-          HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
-          HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
+          if (rootElement)
+            HTMLUtilities.setAttr(rootElement, "data-viewer-theme", "day");
+          if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
         }
         if (this.view?.navigator.publication.isReflowable) {
           // Apply font family


### PR DESCRIPTION
I noticed that the UserSettings will apply the `data-viewer-theme` attributes on the top level document. When reusing the window after the reader was used, that attributes remains, but it should not.

this PR will make use of a `#root` element if exists instead, and else keep the existing behaviour for backward compatibility