### PR TITLE
feat: add navigator api/events for chapterInfo and positionInfo updates

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -117,6 +117,8 @@ export interface NavigatorAPI {
   resourceAtEnd: any;
   resourceFitsScreen: any;
   updateCurrentLocation: any;
+  positionInfo: any;
+  chapterInfo: any;
   direction: any;
   onError?: (e: Error) => void;
 }
@@ -1465,9 +1467,14 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         if (this.chapterTitle)
           this.chapterTitle.innerHTML =
             "(" + this.currentChapterLink.title + ")";
+        if (this.api?.chapterInfo)
+          this.api?.chapterInfo(this.currentChapterLink.title);
+        this.emit("chapterinfo", this.currentChapterLink.title);
       } else {
         if (this.chapterTitle)
           this.chapterTitle.innerHTML = "(Current Chapter)";
+        if (this.api?.chapterInfo) this.api?.chapterInfo(undefined);
+        this.emit("chapterinfo", undefined);
       }
 
       await this.injectInjectablesIntoIframeHead(iframe);
@@ -2716,6 +2723,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             this.chapterPosition.innerHTML =
               "Page " + currentPage + " of " + pageCount;
           }
+          if (this.api?.positionInfo) {
+            this.api?.positionInfo(locator);
+          }
+          this.emit("positioninfo", locator);
         }
       } else {
         if (this.chapterPosition) this.chapterPosition.innerHTML = "";
@@ -3008,9 +3019,14 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           if (this.chapterTitle)
             this.chapterTitle.innerHTML =
               "(" + this.currentChapterLink.title + ")";
+          if (this.api?.chapterInfo)
+            this.api?.chapterInfo(this.currentChapterLink.title);
+          this.emit("chapterinfo", this.currentChapterLink.title);
         } else {
           if (this.chapterTitle)
             this.chapterTitle.innerHTML = "(Current Chapter)";
+          if (this.api?.chapterInfo) this.api?.chapterInfo(undefined);
+          this.emit("chapterinfo", undefined);
         }
         await this.updatePositionInfo();
       } else {


### PR DESCRIPTION
I was trying to use my own component to display the bottom information of the reader:

> Page X of Y (Chapter Title)

I faced various issues while trying to use `api.updateCurrentLocation` to source the information i needed:
1. the function is called with a delay, which was clearly visible in the UI when rendering
2. the function is not called when changing the view mode from vertical scroll to paginated. If you were to navigate to a chapter via the TOC while in vertical scrolling, then changed the pagination to paginated, the api would not be called, and you would not have the correct information.

To solve 2. I tried to use `reader.currentLocator` just after changing the view mode, but since there are some internal timers inside the navigator, i would receive a locator with 0/0 for the page index/count.

This PR adds 2 new APIs / events, which are triggered at the same time/place than when the internal HTML components are updated. This allows to externalize the display with no drawbacks on delay.