### PR TITLE
fix: draw epub2 page breaks

### DIFF
--- a/src/modules/pagebreak/PageBreakModule.ts
+++ b/src/modules/pagebreak/PageBreakModule.ts
@@ -170,6 +170,9 @@ export class PageBreakModule implements ReaderModule {
       if (pageBreaks?.length === 0) {
         pageBreaks = body?.querySelectorAll("[epub\\:type='pagebreak']");
       }
+      if (pageBreaks?.length === 0) {
+        pageBreaks = body?.querySelectorAll("[role='doc-pagebreak']");
+      }
       let self = this;
 
       function getCssSelector(element: Element): string {


### PR DESCRIPTION
only epub3 page breaks would be drawn, this adds support for epub2 page breaks: https://kb.daisy.org/publishing/docs/html/dpub-aria/doc-pagebreak.html