### PR TITLE
feat: IFrameAttributes for fixed layout margin and shadow

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -126,6 +126,8 @@ export interface IFrameAttributes {
   iframePaddingTop?: number;
   bottomInfoHeight?: number;
   sideNavPosition?: "left" | "right";
+  fixedLayoutMargin?: number;
+  fixedLayoutShadow?: boolean;
 }
 export interface IFrameNavigatorConfig {
   mainElement: HTMLElement;
@@ -593,16 +595,20 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             this.iframes.push(iframe2);
 
             secondSpread.appendChild(this.iframes[1]);
-            this.firstSpread.style.clipPath =
-              "polygon(0% -20%, 100% -20%, 100% 120%, -20% 120%)";
-            this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
-            secondSpread.style.clipPath =
-              "polygon(0% -20%, 100% -20%, 120% 100%, 0% 120%)";
-            secondSpread.style.boxShadow = "0 0 8px 2px #ccc";
+            if (this.attributes?.fixedLayoutShadow) {
+              this.firstSpread.style.clipPath =
+                "polygon(0% -20%, 100% -20%, 100% 120%, -20% 120%)";
+              this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+              secondSpread.style.clipPath =
+                "polygon(0% -20%, 100% -20%, 120% 100%, 0% 120%)";
+              secondSpread.style.boxShadow = "0 0 8px 2px #ccc";
+            }
           } else {
-            this.firstSpread.style.clipPath =
-              "polygon(0% -20%, 100% -20%, 120% 100%, -20% 120%)";
-            this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+            if (this.attributes?.fixedLayoutShadow) {
+              this.firstSpread.style.clipPath =
+                "polygon(0% -20%, 100% -20%, 120% 100%, -20% 120%)";
+              this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+            }
           }
         } else {
           this.iframes[0].style.paddingTop =
@@ -2109,12 +2115,15 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             : (this.iframes[0].parentElement?.parentElement as HTMLElement);
         if (iframeParent && width) {
           var widthRatio =
-            (parseInt(getComputedStyle(iframeParent).width) - 100) /
+            (parseInt(getComputedStyle(iframeParent).width) -
+              (this.attributes?.fixedLayoutMargin || 0)) /
             (this.iframes.length === 2
-              ? parseInt(width?.replace("px", "")) * 2 + 200
+              ? parseInt(width?.replace("px", "")) * 2 +
+                2 * (this.attributes?.fixedLayoutMargin || 0)
               : parseInt(width?.replace("px", "")));
           var heightRatio =
-            (parseInt(getComputedStyle(iframeParent).height) - 100) /
+            (parseInt(getComputedStyle(iframeParent).height) -
+              (this.attributes?.fixedLayoutMargin || 0)) /
             parseInt(height?.replace("px", ""));
           var scale = Math.min(widthRatio, heightRatio);
           iframeParent.style.transform = "scale(" + scale + ")";
@@ -2502,12 +2511,14 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         this.spreads.appendChild(secondSpread);
         secondSpread.appendChild(this.iframes[1]);
 
-        this.firstSpread.style.clipPath =
-          "polygon(0% -20%, 100% -20%, 100% 120%, -20% 120%)";
-        this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
-        secondSpread.style.clipPath =
-          "polygon(0% -20%, 100% -20%, 120% 100%, 0% 120%)";
-        secondSpread.style.boxShadow = "0 0 8px 2px #ccc";
+        if (this.attributes?.fixedLayoutShadow) {
+          this.firstSpread.style.clipPath =
+            "polygon(0% -20%, 100% -20%, 100% 120%, -20% 120%)";
+          this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+          secondSpread.style.clipPath =
+            "polygon(0% -20%, 100% -20%, 120% 100%, 0% 120%)";
+          secondSpread.style.boxShadow = "0 0 8px 2px #ccc";
+        }
       } else {
         if (this.iframes.length === 2) {
           this.iframes.pop();
@@ -2515,9 +2526,11 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             this.spreads.removeChild(this.spreads.lastChild);
           }
         }
-        this.firstSpread.style.clipPath =
-          "polygon(0% -20%, 100% -20%, 120% 100%, -20% 120%)";
-        this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+        if (this.attributes?.fixedLayoutShadow) {
+          this.firstSpread.style.clipPath =
+            "polygon(0% -20%, 100% -20%, 120% 100%, -20% 120%)";
+          this.firstSpread.style.boxShadow = "0 0 8px 2px #ccc";
+        }
       }
       this.precessContentForIframe();
     }
@@ -2577,12 +2590,15 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         }
 
         var widthRatio =
-          (parseInt(getComputedStyle(iframeParent).width) - 100) /
+          (parseInt(getComputedStyle(iframeParent).width) -
+            (this.attributes?.fixedLayoutMargin || 0)) /
           (this.iframes.length === 2
-            ? parseInt(width?.replace("px", "")) * 2 + 200
+            ? parseInt(width?.replace("px", "")) * 2 +
+              2 * (this.attributes?.fixedLayoutMargin || 0)
             : parseInt(width?.replace("px", "")));
         var heightRatio =
-          (parseInt(getComputedStyle(iframeParent).height) - 100) /
+          (parseInt(getComputedStyle(iframeParent).height) -
+            (this.attributes?.fixedLayoutMargin || 0)) /
           parseInt(height?.replace("px", ""));
         var scale = Math.min(widthRatio, heightRatio);
         iframeParent.style.transform = "scale(" + scale + ")";

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -960,6 +960,8 @@
                 navHeight: 10, // used for positioning the toolbox
                 iframePaddingTop: 20, // top padding inside iframe
                 bottomInfoHeight: 75, // #reader-info-bottom height
+                fixedLayoutMargin: 100,
+                fixedLayoutShadow: true,
             },
             rights: {
                 enableBookmarks: true,


### PR DESCRIPTION
Currently the fixed layout applies a hardcoded margin of 100px on the side, as well as a drop shadow:
<img width="1465" alt="Screenshot 2023-12-07 at 16 51 38" src="https://github.com/d-i-t-a/R2D2BC/assets/2139133/4b66ac42-7e5a-4644-8512-83c41ddb2e85">

This PR adds 2 new user settings:
- `fixedLayoutMargin` is a positive number that will control the margin. Defaults to the current value of 100.
- `fixedLayoutShadow` is a boolean to display or not the shadow. Defaults to the current value `true`.

Here is a screenshot with margins set at 0:
<img width="1466" alt="Screenshot 2023-12-07 at 17 48 57" src="https://github.com/d-i-t-a/R2D2BC/assets/2139133/d99d794b-1c2d-4f41-a899-4b7e5c1f7e01">

Here is a screenshot with no shadow:
<img width="1466" alt="Screenshot 2023-12-07 at 17 49 19" src="https://github.com/d-i-t-a/R2D2BC/assets/2139133/353a8cd8-f88a-46d4-ad54-64ce0b75dc65">
