### PR TITLE
various iFrame fixes

### DIFF
--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -197,7 +197,7 @@ export class AnnotationModule implements ReaderModule {
     }, 200);
   }
 
-  initialize() {
+  initialize(iframe: HTMLIFrameElement) {
     return new Promise(async (resolve) => {
       await (document as any).fonts.ready;
       if (this.rights.enableAnnotations) {
@@ -205,7 +205,7 @@ export class AnnotationModule implements ReaderModule {
           this.drawHighlights();
           this.showHighlights();
           addEventListenerOptional(
-            this.navigator.iframes[0].contentDocument?.body,
+            iframe.contentDocument?.body,
             "click",
             this.click.bind(this)
           );

--- a/src/modules/consumption/ConsumptionModule.ts
+++ b/src/modules/consumption/ConsumptionModule.ts
@@ -84,8 +84,9 @@ export class ConsumptionModule implements ReaderModule {
     log.log("Consumption module stop");
     this.endResearchSession();
   }
-  initialize() {
-    let win = this.navigator.iframes[0].contentWindow;
+
+  initialize(iframe: HTMLIFrameElement) {
+    let win = iframe.contentWindow;
     if (win) {
       const self = this;
       win.onload = function () {

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -191,16 +191,12 @@ export class TextHighlighter {
       onAfterHighlight: function () {},
     });
   }
-  async initialize() {
-    let doc = this.navigator.iframes[0].contentDocument;
+  async initialize(iframe: HTMLIFrameElement) {
+    let doc = iframe.contentDocument;
     if (doc) {
       this.dom(doc.body).addClass(this.options.contextClass);
     }
-    this.bindEvents(
-      this.navigator.iframes[0].contentDocument?.body,
-      this,
-      this.hasEventListener
-    );
+    this.bindEvents(iframe.contentDocument?.body, this, this.hasEventListener);
 
     this.initializeToolbox();
 
@@ -218,7 +214,7 @@ export class TextHighlighter {
       }
     }
     setTimeout(async () => {
-      let doc = this.navigator.iframes[0].contentDocument;
+      let doc = iframe.contentDocument;
       if (doc) {
         await doc.body?.addEventListener("click", unselect);
       }

--- a/src/modules/linefocus/LineFocusModule.ts
+++ b/src/modules/linefocus/LineFocusModule.ts
@@ -135,7 +135,8 @@ export default class LineFocusModule implements ReaderModule {
       }
     }
   }
-  initialize() {
+
+  initialize(iframe: HTMLIFrameElement) {
     return new Promise(async (resolve) => {
       await (document as any).fonts.ready;
       if (!this.hasEventListener) {
@@ -143,12 +144,12 @@ export default class LineFocusModule implements ReaderModule {
         addEventListenerOptional(document, "keydown", this.keydown.bind(this));
         addEventListenerOptional(document, "keyup", this.keyup.bind(this));
         addEventListenerOptional(
-          this.navigator.iframes[0].contentDocument,
+          iframe.contentDocument,
           "keydown",
           this.keydown.bind(this)
         );
         addEventListenerOptional(
-          this.navigator.iframes[0].contentDocument,
+          iframe.contentDocument,
           "keyup",
           this.keyup.bind(this)
         );

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -897,36 +897,34 @@ export class ContentProtectionModule implements ReaderModule {
     }
   }
 
-  public async initialize() {
+  public async initialize(iframe: HTMLIFrameElement) {
     if (this.properties?.enableObfuscation) {
       return new Promise<void>(async (resolve) => {
         await (document as any).fonts.ready;
-        for (const iframe of this.navigator.iframes) {
-          if (iframe.contentDocument) {
-            const body = HTMLUtilities.findRequiredIframeElement(
-              iframe.contentDocument,
-              "body"
-            ) as HTMLBodyElement;
-            this.observe();
+        if (iframe.contentDocument) {
+          const body = HTMLUtilities.findRequiredIframeElement(
+            iframe.contentDocument,
+            "body"
+          ) as HTMLBodyElement;
+          this.observe();
 
-            setTimeout(() => {
-              this.rects = this.findRects(body);
-              this.rects.forEach((rect) =>
-                this.toggleRect(rect, this.securityContainer, this.isHacked)
+          setTimeout(() => {
+            this.rects = this.findRects(body);
+            this.rects.forEach((rect) =>
+              this.toggleRect(rect, this.securityContainer, this.isHacked)
+            );
+
+            this.setupEvents();
+            if (!this.hasEventListener) {
+              this.hasEventListener = true;
+              addEventListenerOptional(
+                this.wrapper,
+                "scroll",
+                this.handleScroll.bind(this)
               );
-
-              this.setupEvents();
-              if (!this.hasEventListener) {
-                this.hasEventListener = true;
-                addEventListenerOptional(
-                  this.wrapper,
-                  "scroll",
-                  this.handleScroll.bind(this)
-                );
-              }
-              resolve();
-            }, 10);
-          }
+            }
+            resolve();
+          }, 10);
         }
       });
     }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2008,24 +2008,24 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               }
             } else {
               this.iframes[0].src = "about:blank";
-            }
-            if (this.iframes.length === 2) {
-              this.currentSpreadLinks.right = {
-                href: this.currentChapterLink.href,
-              };
+              if (this.iframes.length === 2) {
+                this.currentSpreadLinks.right = {
+                  href: this.currentChapterLink.href,
+                };
 
-              if (isSameOrigin) {
-                this.iframes[1].src = this.currentChapterLink.href;
-              } else {
-                fetch(this.currentChapterLink.href, this.requestConfig)
-                  .then((r) => r.text())
-                  .then(async (content) => {
-                    writeIframe2Doc.call(
-                      this,
-                      content,
-                      this.currentChapterLink.href
-                    );
-                  });
+                if (isSameOrigin) {
+                  this.iframes[1].src = this.currentChapterLink.href;
+                } else {
+                  fetch(this.currentChapterLink.href, this.requestConfig)
+                    .then((r) => r.text())
+                    .then(async (content) => {
+                      writeIframe2Doc.call(
+                        this,
+                        content,
+                        this.currentChapterLink.href
+                      );
+                    });
+                }
               }
             }
           }

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1441,7 +1441,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
       await this.injectInjectablesIntoIframeHead(iframe);
 
-      if (this.highlighter !== undefined) {
+      if (this.view?.layout !== "fixed" && this.highlighter !== undefined) {
         await this.highlighter.initialize(iframe);
       }
       const body = iframe.contentDocument?.body;


### PR DESCRIPTION
this PR fixes a few iFrame bugs i found while trying to make the fixed view double pages work.

The second iframe would be loaded twice in some cases, which did generate problem on Firefox only. When loading the book with a previously saved progress, the second iframe would not have any events registered. It would also not load when changing pages.

In the navigator, `handleIFrameLoad` would be registered for each iFrame. But within that function, the code would often either only care about `this.iframes[0]`, or loop through `this.iframes`. Since the function would be called twice when showing 2 iframes, duplicate effects would be generated, for instance all the event listeners would be duplicated.

I also disable the highlighter in fixed view mode. Whenever a click would occur on one of the page (usually images), the toolbox would be showing somehow. This fixes it.