### PR TITLE
feat: expose publicationLayout in the reader

### DIFF
--- a/src/reader.ts
+++ b/src/reader.ts
@@ -590,6 +590,10 @@ export default class D2Reader {
     return this.annotationModule?.getAnnotations();
   }
 
+  get publicationLayout() {
+    return this.navigator.publication.layout;
+  }
+
   /** History */
   get history() {
     return this.historyModule?.history;


### PR DESCRIPTION
this exposes the publication layout on the reader instance. This is useful to customize the page elements depending on whether the layout is fixed or reflowable.