### PR TITLE
Customize highlighter color

### DIFF
--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -1080,7 +1080,7 @@ export class UserSettings implements IUserSettings {
       }
     }
 
-    if (userSettings.letterSpacing) {
+    if (userSettings.letterSpacing !== undefined) {
       this.letterSpacing = userSettings.letterSpacing;
       let prop = this.userProperties?.getByRef(ReadiumCSS.LETTER_SPACING_REF);
       if (prop) {

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -72,6 +72,7 @@ export interface IUserSettings {
   //Advanced settings
   // publisherDefaults: boolean;
   textAlignment: number;
+  textAlignmentValue?: string; // "auto" | "justify" | "start"
   columnCount: number;
   direction: number;
   wordSpacing: number;
@@ -143,6 +144,7 @@ export class UserSettings implements IUserSettings {
   //Advanced settings
   // publisherDefaults = true;
   textAlignment = 0;
+  textAlignmentValue = "auto";
   columnCount = 0;
   direction = 0;
   wordSpacing = 0.0;
@@ -1121,7 +1123,18 @@ export class UserSettings implements IUserSettings {
 
     if (userSettings.textAlignment) {
       this.textAlignment = UserSettings.textAlignmentValues.findIndex(
-        (el: any) => el === userSettings.textAlignment
+        (_: any, index: number) => index === userSettings.textAlignment
+      );
+      let prop = this.userProperties?.getByRef(ReadiumCSS.TEXT_ALIGNMENT_REF);
+      if (prop) {
+        prop.value = this.textAlignment;
+        await this.storeProperty(prop);
+      }
+    }
+
+    if (userSettings.textAlignmentValue) {
+      this.textAlignment = UserSettings.textAlignmentValues.findIndex(
+        (el: string) => el === userSettings.textAlignmentValue
       );
       let prop = this.userProperties?.getByRef(ReadiumCSS.TEXT_ALIGNMENT_REF);
       if (prop) {

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -144,6 +144,7 @@ export interface TextHighlighterProperties {
 export interface TextHighlighterConfig extends TextHighlighterProperties {
   api?: TextSelectorAPI;
   layerSettings: LayerSettings;
+  colors?: string[];
 }
 
 export class TextHighlighter {
@@ -155,6 +156,15 @@ export class TextHighlighter {
   private api?: TextSelectorAPI;
   private hasEventListener: boolean;
   activeAnnotationMarkerId?: string = undefined;
+  colors: string[] = [
+    "#fce300",
+    "#48e200",
+    "#00bae5",
+    "#157cf9",
+    "#6a39b7",
+    "#ea426a",
+    "#ff8500",
+  ];
 
   public static async create(config: TextHighlighterConfig): Promise<any> {
     const module = new this(
@@ -162,7 +172,8 @@ export class TextHighlighter {
       config as TextHighlighterProperties,
       false,
       {},
-      config.api
+      config.api,
+      config.colors
     );
     return new Promise((resolve) => resolve(module));
   }
@@ -172,7 +183,8 @@ export class TextHighlighter {
     properties: TextHighlighterProperties,
     hasEventListener: boolean,
     options: any,
-    api?: TextSelectorAPI
+    api?: TextSelectorAPI,
+    colors?: string[]
   ) {
     this.layerSettings = layerSettings;
     this.properties = properties;
@@ -181,8 +193,13 @@ export class TextHighlighter {
     }
     this.api = api;
     this.hasEventListener = hasEventListener;
+
+    if (colors && colors.length > 0) {
+      this.colors = colors;
+    }
+
     this.options = this.defaults(options, {
-      color: "#fce300",
+      color: colors?.[0] ?? "#fce300",
       highlightedClass: "highlighted",
       contextClass: "highlighter-context",
       onBeforeHighlight: function () {
@@ -750,15 +767,6 @@ export class TextHighlighter {
       "highlight-toolbox-mode-colors"
     );
     let toolboxOptions = document.getElementById("highlight-toolbox-mode-add");
-    let colors = [
-      "#fce300",
-      "#48e200",
-      "#00bae5",
-      "#157cf9",
-      "#6a39b7",
-      "#ea426a",
-      "#ff8500",
-    ];
     let colorIcon = document.getElementById("colorIcon");
     let actionIcon = document.getElementById("actionIcon");
     let dismissIcon = document.getElementById("dismissIcon");
@@ -785,7 +793,7 @@ export class TextHighlighter {
       colorIcon.style.position = "relative";
       colorIcon.style.zIndex = "20";
 
-      colors.forEach((color) => {
+      this.colors.forEach((color) => {
         let colorButton = document.getElementById(color);
         let cButton = document.getElementById(`c${color}`);
         if (colorButton && toolboxColorsOptions?.contains(colorButton)) {
@@ -806,7 +814,7 @@ export class TextHighlighter {
 
       if (this.navigator.rights.enableAnnotations) {
         let index = 10;
-        colors.forEach((color) => {
+        this.colors.forEach((color) => {
           index--;
           const colorButton = colorIcon?.cloneNode(true) as HTMLButtonElement;
           const colorButtonSymbol = colorButton.lastChild as HTMLElement;
@@ -825,7 +833,7 @@ export class TextHighlighter {
       }
 
       // Generate color options
-      colors.forEach((color) => {
+      this.colors.forEach((color) => {
         const colorButton = colorIcon?.cloneNode(true) as HTMLButtonElement;
         const colorButtonSymbol = colorButton.lastChild as HTMLElement;
         colorButtonSymbol.style.backgroundColor = color;

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -522,15 +522,21 @@ export default class D2Reader {
   addAnnotation = async (highlight: Annotation) => {
     return (await this.annotationModule?.addAnnotation(highlight)) ?? false;
   };
-  /** 
+  /**
    * Update annotation
-   * 
+   *
    * This should be used only when the add/delete of the annotation note
    * is not directly handled in the `addAnnotation`/`addCommentToAnnotation`
    * callback defined in the configuration of the D2Reader.load() method
    *  */
   updateAnnotation = async (highlight: Annotation) => {
     return (await this.annotationModule?.updateAnnotation(highlight)) ?? false;
+  };
+  /**
+   * Change highlighter color to specific HEX string
+   */
+  changeHighlighterColor = (color: string) => {
+    this.highlighter?.setColor(color);
   };
 
   /** Hide Annotation Layer */

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1218,6 +1218,8 @@
                     },
                 },
                 preventScrollOnSelection: true,
+                // Set a different set of HEX colors, the first item will be the starting highlighting color
+                // colors: ['#e2725b', '#00a693', '#87cefa'],
             },
             annotations: {
                 enableComments: true,


### PR DESCRIPTION
This PR adds a config to the `TextHighlighter` module which enables the user to define a custom set of `hex` colors as an `array of strings` as options to highlight text.

If the config is `undefined` or an `empty array` resorts to the default set of colors already present in the code.

The PR also adds a method in the `reader.ts` file to directly change the highlight color, giving the user the option to handle the highlighting color via external elements and not the one defined by the `TextHighlighter` module.

Closes #855 