### PR TITLE
Fix for media overlay bugs in fixed layout books

### DIFF
--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -203,7 +203,7 @@ export class MediaOverlayModule implements ReaderModule {
       this.settings.playing = true;
       if (
         this.audioElement &&
-        this.currentLinks[this.currentLinkIndex]?.Properties.MediaOverlay
+        this.currentLinks[this.currentLinkIndex]?.Properties?.MediaOverlay
       ) {
         const timeToSeekTo = this.currentAudioBegin
           ? this.currentAudioBegin

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1730,6 +1730,8 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
     var even: boolean = (index ?? 0) % 2 === 1;
     this.showLoadingMessageAfterDelay();
 
+    this.currentSpreadLinks = {};
+
     function writeIframeDoc(content: string, href: string) {
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, "application/xhtml+xml");
@@ -1990,6 +1992,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
                     this.currentChapterLink.href
                   );
                 });
+              this.currentSpreadLinks.left = {
+                href: this.currentChapterLink.href,
+              };
               if (this.iframes.length === 2) {
                 if ((index ?? 0) < this.publication.readingOrder.length - 1) {
                   const next = this.publication.getNextSpineItem(

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2031,6 +2031,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
                   this.iframes[0].src = href;
                   if (this.iframes.length === 2) {
                     this.iframes[1].src = this.currentChapterLink.href;
+                    this.currentSpreadLinks.right = {
+                      href: this.currentChapterLink.href,
+                    };
                   }
                 } else {
                   fetch(href, this.requestConfig)


### PR DESCRIPTION
We experienced several problems when we were trying to play mediaoverlays in fixed layout books.

1. When the book is not opened on the first page, playing media overlays would only read every second page (only left or right spreadlink was set)
2. When reaching the last page of the book and the last page was in the left iframe, the mediaoverlay was also reading the previous page in the right iframe (missing initialization of currentSpreadLinks when switching pages)
3. When navigating to the first page after some mediaoverlay was played, the code would throw an unhandled exception (first page is always in right iframe, the left iframe might be about:blank, so `this.currentLinks[this.currentLinkIndex]?.Properties`  in the mediaoverlay module is not always available).

These commits seem to solve the above problems.