### PR TITLE
Fix FXL spread link cleanup on blank pages

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1847,6 +1847,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
                 }
               } else {
                 this.iframes[1].src = "about:blank";
+                this.currentSpreadLinks.right = undefined;
               }
             }
           } else {
@@ -1877,6 +1878,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               }
             } else {
               this.iframes[0].src = "about:blank";
+              this.currentSpreadLinks.left = undefined;
             }
             if (this.iframes.length === 2 && this.publication.isFixedLayout) {
               this.currentSpreadLinks.right = {
@@ -1983,6 +1985,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
                   }
                 } else {
                   this.iframes[1].src = "about:blank";
+                  this.currentSpreadLinks.right = undefined;
                 }
               }
             } else {
@@ -2017,6 +2020,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
                   }
                 } else {
                   this.iframes[1].src = "about:blank";
+                  this.currentSpreadLinks.right = undefined;
                 }
               }
             }
@@ -2062,6 +2066,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               }
             } else {
               this.iframes[0].src = "about:blank";
+              this.currentSpreadLinks.left = undefined;
               if (this.iframes.length === 2) {
                 this.currentSpreadLinks.right = {
                   href: this.currentChapterLink.href,


### PR DESCRIPTION
## Summary

- Clear `currentSpreadLinks.left/right` when the corresponding iframe is set to `about:blank`
- Fixes a bug where 2-page FXL layout replays stale content after the last page

Inspired by #1010.

## Test plan

- [ ] FXL book with odd page count doesn't replay content on last spread
- [ ] Build succeeds