### PR TITLE
docs: update README for v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,59 +4,37 @@
 
 # R2D2BC
 
-# Introduction
-**R2D2BC** is an implementation of the [Readium v2](https://github.com/readium/architecture) EPUB reader for the web.
-It is built as a modular toolkit (rather than a full-featured app) so that applications can use it to 
-handle the EPUB-related functions while customizing the own design, user interface, and extensions.
+## Introduction
+**R2D2BC** is an implementation of the [Readium v2](https://github.com/readium/architecture) EPUB and PDF reader for the web.
+It is built as a modular toolkit (rather than a full-featured app) so that applications can use it to
+handle publication-related functions while customizing their own design, user interface, and extensions.
 
-# Goals
+## Goals
 
 - Follow the Readium architecture specification for best interoperability
-- Allow maximum configurability via API methods, callbacks, code and style injection, and clear separation of functions.
-- Modularity 
+- Allow maximum configurability via API methods, callbacks, code and style injection, and clear separation of functions
+- Modularity
 - Clarity of code and ease of maintenance
 - Speed
 - Accessibility
 - Free and open source
 
-The R2D2BC project intentionally includes only a base-bones demonstration user interface, and no sample content.
+The R2D2BC project intentionally includes only a bare-bones demonstration user interface, and no sample content.
 Any implementer can add their own functionality and design without refactoring the whole project.
 
-See below for projects that provide the necessary other elements to try it out and see it in action.
+## Features
 
-# Architecture
-
-This project implements most components of the [Readium Architecture](https://github.com/readium/architecture):
-
-- Implements Locator
-- Implements UserSettings
-- Implements Webpub Manifest
-- Implements the Readium shared models
-- Integrates Readium CSS
-- Integrates a simple Navigator for reflowable publications
-
-Additionally, it:
-- Provides a decoupled Minimal UI
-- Provides build system optimization (Webpack)
-
-# Origins
-
-Here is the original proposal, initiated by Aferdita Muriqi to the
-[Readium Weekly Eng Meeting - 05/22/2019](https://docs.google.com/document/d/1krNe8TUtvajpljcSS4nN_2cHfWO4_Hsag5LnJ4hj_CM/edit#)
-
-Subsequent development of R2D2BC has been supported by [DITA](https://github.com/d-i-t-a), [Bokbasen](https://www.bokbasen.no/), and [CAST](http://www.cast.org) - which explains the D2, B, and C in the name.
-
-# Features & Functionalities
-- ePub Reflowable + Fixed Layout
-- Reader Settings
+- EPUB Reflowable + Fixed Layout
+- PDF (via pdfjs-dist v5)
+- Reader Settings (font, size, spacing, colors, layout, margins)
 - Configurable Modules with Callbacks
-- Injectable Fonts, CSS, Javascript
+- Injectable Fonts, CSS, JavaScript
 - Text Selection with Injectable Context Menu
 - Bookmarks
-- Highlights
+- Highlights (configurable colors)
 - Annotations
-- TTS - Text to speech / Read Aloud
-- Media Overlays - Read Along
+- TTS - Text to Speech / Read Aloud
+- Media Overlays - Read Along (with click-to-advance)
 - Search
 - Content Protection
 - Definitions
@@ -64,50 +42,79 @@ Subsequent development of R2D2BC has been supported by [DITA](https://github.com
 - Page Breaks - Page Numbers in margin
 - Sample Read
 - Timeline
+- Consumption Tracking
 - Layers
-- Line Focus (Beta Feature)
-- Popups and Popovers
+- Line Focus
+- History Navigation
+- Citations
 
-# Extensions and Implementations
+## Architecture
+
+This project implements most components of the [Readium Architecture](https://github.com/readium/architecture):
+
+- Implements Locator
+- Implements UserSettings
+- Implements Webpub Manifest
+- Implements the Readium shared models
+- Integrates Readium CSS v1.1.1
+- Implements Navigator for reflowable and fixed-layout publications
+- Implements PDF Navigator (pdfjs-dist v5)
+
+## Origins
+
+Here is the original proposal, initiated by Aferdita Muriqi to the
+[Readium Weekly Eng Meeting - 05/22/2019](https://docs.google.com/document/d/1krNe8TUtvajpljcSS4nN_2cHfWO4_Hsag5LnJ4hj_CM/edit#)
+
+Subsequent development of R2D2BC has been supported by [DITA](https://github.com/d-i-t-a), [Bokbasen](https://www.bokbasen.no/), and [CAST](http://www.cast.org) - which explains the D2, B, and C in the name.
+
+## Extensions and Implementations
 
 The R2D2BC reader has been used in:
 - The [Clusive](https://github.com/cast-org/clusive) learning environment
-- Bokbasen's [Allbok.no](https://www.allbok.no) 
+- Bokbasen's [Allbok.no](https://www.allbok.no)
 - Allvir's [Allvit.no](https://www.allvit.no) Reading Platform
 - The UNODC [Fieldguides](https://fieldguides.github.io/library)
 - The DITA Gateway [D2G](https://d2g.dita.digital) with several open collections
 - [Ekitabu's](https://d2g.dita.digital) Web Reader Implementations through Dita Gateway
 - [NYPL's](https://www.nypl.org/) Web Reader Implementations
 - Bibliotheca's [CloudLibrary](https://www.yourcloudlibrary.com) as Sample Reader and Full ePub Reader
-- Above the Treeline's [Edeweiss+](https://www.edelweiss.plus) 
+- Above the Treeline's [Edelweiss+](https://www.edelweiss.plus)
 - [Bluefire's](https://www.bluefirereader.com) Web Reader Implementations
-- In a Project in the Meta Verse (to be named once public)
-- and a few more... :) 
+- and more...
 
+## Get Started
 
-# Contributing
-Contributions are always welcomed! Please see [CONTRIBUTING](CONTRIBUTING.md) for detailed guidelines.
-
-[![DepShield Badge](https://depshield.sonatype.org/badges/d-i-t-a/R2D2BC/depshield.svg)](https://depshield.github.io)
-
-# Get Started
-
-Download ebook examples here: https://standardebooks.org/ebooks and copy them to `./examples/epubs`. Then:
-
-```
+```bash
 npm install
-
 npm run build && npm run examples
 ```
-Then visit `http://localhost:4444/`. Follow the prompts to view example apps.
 
-### WIKI
-- [Implementation Guides and Examples](https://github.com/d-i-t-a/R2D2BC/wiki)
+Then visit `http://localhost:4444/`. The landing page shows available publications and example viewers.
 
-### Migration Guides
-- [Version 1.x -> 2.x](MIGRATION.md)
-### Change Log
-- [2.0.x](CHANGELOG.md)
+### Framework Examples
+
+Examples are included for React, Vue, Angular, Next.js, Remix, and Vanilla JS:
+
+```bash
+npm run example:react
+npm run example:vue
+npm run example:angular
+npm run example:vanilla
+```
+
+See [examples/README.md](examples/README.md) for full details.
+
+## Documentation
+
+- [Full Documentation](DOCUMENTATION.md)
+- [Migration Guide: 1.x to 2.x](MIGRATION.md)
+- [Changelog](CHANGELOG.md)
+- [Examples Guide](examples/README.md)
+
+## Contributing
+
+Contributions are always welcomed! Please see [CONTRIBUTING](CONTRIBUTING.md) for detailed guidelines.
 
 ## Supporters
+
 [<img src="https://dita.digital/jetbrains.png" width="60">](https://www.jetbrains.com/?from=R2D2BC)


### PR DESCRIPTION
## Summary

- Update README to reflect v2.5.0 features (PDF, highlight colors, MO click-to-advance, etc.)
- Replace wiki reference with DOCUMENTATION.md link
- Add framework examples section
- Remove outdated references (Webpack, DepShield)

## Test plan

- [ ] README renders correctly on GitHub