### PR TITLE
v3 workstream 3.1: Typed event system with enriched payloads

### DIFF
--- a/CHANGES-v3-event-system.md
+++ b/CHANGES-v3-event-system.md
@@ -1,0 +1,100 @@
+# Workstream 3.1 — Event System
+
+## What Changed
+
+- New `src/utils/Events.ts` — typed `ReaderEvent` constants and `ReaderEventMap` payload types
+- `ReaderEvent`, `ReaderEventName`, and `ReaderEventMap` exported from `index.ts`
+- Every emit uses `ReaderEvent` constants — no raw strings anywhere in the codebase
+- Every notification callback now has a matching event
+- Both paths are intentional: callbacks for two-way (integrator returns data), events for one-way (notifications)
+- Pattern: callback fires first, event emits after
+- MediaOverlay API callbacks (`started`, `stopped`, `paused`, `resumed`, `finished`) were defined but never wired — now connected
+- All events carry useful payload data (locator, href, text, etc.) as additional arguments
+
+### New Events Added
+
+| Event | Module | Payload |
+|-------|--------|---------|
+| `readalong.started` | MediaOverlay | "started", { href } |
+| `readalong.stopped` | MediaOverlay | "stopped", { href } |
+| `readalong.paused` | MediaOverlay | "paused", { href } |
+| `readalong.resumed` | MediaOverlay | "resumed", { href } |
+| `readalong.finished` | MediaOverlay | "finished", { href } |
+| `bookmark.created` | Bookmark | Bookmark object |
+| `bookmark.deleted` | Bookmark | Bookmark object |
+| `annotation.created` | Annotation | Annotation object |
+| `annotation.deleted` | Annotation | Annotation object |
+| `annotation.updated` | Annotation | Annotation object |
+| `annotation.selected` | TextHighlighter | Annotation object |
+| `annotation.comment.added` | TextHighlighter | Annotation object |
+| `text.selected` | TextHighlighter | { text, selection } |
+| `citation.created` | Citation | message string |
+| `citation.failed` | Citation | message string |
+| `location.changed` | Both navigators | ReadingPosition object |
+| `error` | IFrameNavigator | Error object |
+| `consumption.action` | Consumption | { locator, action } |
+| `consumption.idle` | Consumption | seconds (number) |
+
+### Enriched Existing Event Payloads
+
+| Event | Before | After (backwards compat) |
+|-------|--------|--------------------------|
+| `resource.ready` | no payload | { href } |
+| `resource.start` | no payload | { href } |
+| `resource.end` | no payload | { href } |
+| `resource.fits` | no payload | { href } |
+| `readaloud.started` | "started" | "started", { locator } |
+| `readaloud.stopped` | "stopped" | "stopped", { locator } |
+| `readaloud.paused` | "paused" | "paused", { locator } |
+| `readaloud.resumed` | "resumed" | "resumed", { locator } |
+| `readaloud.finished` | "finished" | "finished", { locator } |
+| `toolbox.opened` | "opened" | "opened", { text } |
+
+### Bugs Fixed During This Workstream
+
+- **text.selected flooding** — was firing dozens of times per selection via `selectionchange` events. Moved to `selectionMenuOpened` where `isSelectionMenuOpen` guard ensures it fires once.
+- **readaloud.stopped firing without TTS active** — `cancel()` was emitting stopped even when TTS was never started. Added `this.speaking` guard.
+- **readalong.stopped firing without MO active** — `stopReadAloud()` was emitting stopped during initialization. Removed events from `stopReadAloud()`, only callers emit based on context.
+- **readalong.stopped + readalong.finished both firing** — natural end of book was emitting stopped then finished. Now only `finished` fires for natural end, `stopped` for autoTurn-off chapter end.
+- **readalong.finished end-of-book detection** — checks if next spine item exists. If no next resource and autoTurn is on, emits `finished`.
+- **definition.success spam** — was emitting for empty results on every settings change. Now only emits when results are found.
+- **FXL rendition.layout detection** — added nested `rendition.layout` check (Snow White format). *(Committed to 3.0 branch)*
+- **FXL injectablesFixed** — added style.css to viewer injectablesFixed for MO highlighting in FXL content. *(Viewer config)*
+
+## What Breaks
+
+**Nothing breaks.** All existing event strings still work. First argument on TTS/MO events unchanged ("started", "stopped", etc.). New data added as additional arguments that existing listeners can ignore.
+
+## How to Migrate
+
+No migration needed. Optionally adopt typed events and enriched payloads:
+
+```typescript
+import { ReaderEvent } from "@d-i-t-a/reader";
+
+// Old (still works)
+reader.addEventListener("resource.ready", () => { ... });
+reader.addEventListener("readaloud.started", (detail) => { ... });
+
+// New — typed constant
+reader.addEventListener(ReaderEvent.ResourceReady, (data) => {
+  console.log("Resource ready:", data.href);
+});
+
+// New — enriched payloads
+reader.addEventListener(ReaderEvent.ReadAloudStarted, (detail, data) => {
+  console.log("TTS started at:", data.locator);
+});
+
+reader.addEventListener(ReaderEvent.BookmarkCreated, (bookmark) => {
+  console.log("Bookmark at:", bookmark.href);
+});
+
+reader.addEventListener(ReaderEvent.LocationChanged, (position) => {
+  console.log("Now at:", position.locations.progression);
+});
+```
+
+## Important: Callbacks vs Events
+
+**Callbacks** can return data — the integrator processes and returns a result (e.g., `addBookmark` returns a bookmark with a server-assigned ID). **Events** are one-way notifications. They are complementary, not interchangeable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.7",
+  "version": "3.0.0-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "3.0.0-alpha.7",
+      "version": "3.0.0-alpha.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@readium/shared": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.7",
+  "version": "3.0.0-alpha.8",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,11 @@ export {
   AnnotationMarker,
 } from "./model/Locator";
 
+// ─── Events ─────────────────────────────────────────────────────────────────
+
+export { ReaderEvent } from "./utils/Events";
+export type { ReaderEventName, ReaderEventMap } from "./utils/Events";
+
 // ─── Navigator / Config ─────────────────────────────────────────────────────
 
 export type {

--- a/src/model/v3/Link.ts
+++ b/src/model/v3/Link.ts
@@ -51,8 +51,10 @@ export class Link extends ReadiumLink {
    * The manifest JSON uses hyphenated key "media-overlay".
    */
   get mediaOverlay(): string | undefined {
-    return this.properties?.otherProperties?.["media-overlay"]
-      ?? this.properties?.otherProperties?.["mediaOverlay"];
+    return (
+      this.properties?.otherProperties?.["media-overlay"] ??
+      this.properties?.otherProperties?.["mediaOverlay"]
+    );
   }
 
   /**

--- a/src/model/v3/Publication.ts
+++ b/src/model/v3/Publication.ts
@@ -170,8 +170,8 @@ export class Publication {
     // "rendition:layout": "pre-paginated" (colon key)
     // "rendition": { "layout": "fixed" } (nested object)
     const renditionLayout =
-      this.metadata?.otherMetadata?.["rendition:layout"]
-      ?? this.metadata?.otherMetadata?.rendition?.layout;
+      this.metadata?.otherMetadata?.["rendition:layout"] ??
+      this.metadata?.otherMetadata?.rendition?.layout;
     return renditionLayout === "pre-paginated" || renditionLayout === "fixed";
   }
 

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -48,6 +48,7 @@ import {
 import * as lodash from "lodash";
 import log from "loglevel";
 import { Action } from "./consumption/ConsumptionModule";
+import { ReaderEvent } from "../utils/Events";
 
 export type Highlight = (highlight: Annotation) => Promise<Annotation>;
 
@@ -331,9 +332,11 @@ export class AnnotationModule implements ReaderModule {
 
   public async deleteAnnotation(highlight: Annotation): Promise<any> {
     await this.deleteLocalHighlight(highlight.id);
+    this.navigator.emit(ReaderEvent.AnnotationDeleted, highlight);
   }
   public async addAnnotation(highlight: Annotation): Promise<any> {
     await this.annotator?.saveAnnotation(highlight);
+    this.navigator.emit(ReaderEvent.AnnotationCreated, highlight);
     await this.showHighlights();
     await this.drawHighlights();
   }
@@ -342,9 +345,11 @@ export class AnnotationModule implements ReaderModule {
     if (this.api?.deleteAnnotation) {
       this.api?.deleteAnnotation(highlight).then(async () => {
         this.deleteLocalHighlight(highlight.id);
+        this.navigator.emit(ReaderEvent.AnnotationDeleted, highlight);
       });
     } else {
       this.deleteLocalHighlight(highlight.id);
+      this.navigator.emit(ReaderEvent.AnnotationDeleted, highlight);
     }
   }
 
@@ -352,9 +357,11 @@ export class AnnotationModule implements ReaderModule {
     if (this.api?.deleteAnnotation) {
       this.api.deleteAnnotation(highlight).then(async () => {
         this.deleteLocalHighlight(highlight.id);
+        this.navigator.emit(ReaderEvent.AnnotationDeleted, highlight);
       });
     } else {
       this.deleteLocalHighlight(highlight.id);
+      this.navigator.emit(ReaderEvent.AnnotationDeleted, highlight);
     }
   }
 
@@ -362,9 +369,11 @@ export class AnnotationModule implements ReaderModule {
     if (this.api?.updateAnnotation) {
       this.api.updateAnnotation(highlight).then(async () => {
         this.updateLocalHighlight(highlight);
+        this.navigator.emit(ReaderEvent.AnnotationUpdated, highlight);
       });
     } else {
       this.updateLocalHighlight(highlight);
+      this.navigator.emit(ReaderEvent.AnnotationUpdated, highlight);
     }
   }
 
@@ -457,6 +466,7 @@ export class AnnotationModule implements ReaderModule {
             try {
               let result = await this.api.addAnnotation(annotation);
               const saved = await this.annotator.saveAnnotation(result);
+              this.navigator.emit(ReaderEvent.AnnotationCreated, saved);
               await this.showHighlights();
               await this.drawHighlights();
               return new Promise<Annotation>((resolve) => resolve(saved));
@@ -466,6 +476,7 @@ export class AnnotationModule implements ReaderModule {
             }
           } else {
             const saved = await this.annotator.saveAnnotation(annotation);
+            this.navigator.emit(ReaderEvent.AnnotationCreated, saved);
             await this.showHighlights();
             await this.drawHighlights();
             return new Promise<Annotation>((resolve) => resolve(saved));

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -43,6 +43,7 @@ import { getClientRectsNoOverlap } from "./highlight/common/rect-utils";
 import { _highlights } from "./highlight/TextHighlighter";
 import log from "loglevel";
 import { Action } from "./consumption/ConsumptionModule";
+import { ReaderEvent } from "../utils/Events";
 
 export interface BookmarkModuleAPI {
   addBookmark: (bookmark: Bookmark) => Promise<Bookmark>;
@@ -178,6 +179,7 @@ export class BookmarkModule implements ReaderModule {
         let deleted = await this.annotator.deleteBookmark(bookmark);
 
         log.log("Bookmark deleted " + JSON.stringify(deleted));
+        this.navigator.emit(ReaderEvent.BookmarkDeleted, bookmark);
         await this.showBookmarks();
         await this.drawBookmarks();
         return deleted;
@@ -185,6 +187,7 @@ export class BookmarkModule implements ReaderModule {
         let deleted = await this.annotator.deleteBookmark(bookmark);
 
         log.log("Bookmark deleted " + JSON.stringify(deleted));
+        this.navigator.emit(ReaderEvent.BookmarkDeleted, bookmark);
         await this.showBookmarks();
         await this.drawBookmarks();
         return deleted;
@@ -269,6 +272,7 @@ export class BookmarkModule implements ReaderModule {
             let saved = this.annotator.saveBookmark(bookmark);
 
             log.log("Bookmark added " + JSON.stringify(saved));
+            this.navigator.emit(ReaderEvent.BookmarkCreated, bookmark);
             this.showBookmarks();
             await this.drawBookmarks();
             return saved;
@@ -276,6 +280,7 @@ export class BookmarkModule implements ReaderModule {
             let saved = this.annotator.saveBookmark(bookmark);
 
             log.log("Bookmark added " + JSON.stringify(saved));
+            this.navigator.emit(ReaderEvent.BookmarkCreated, bookmark);
             this.showBookmarks();
             await this.drawBookmarks();
             return saved;
@@ -507,11 +512,13 @@ export class BookmarkModule implements ReaderModule {
           if (this.api?.addBookmark) {
             let result = await this.api.addBookmark(annotation);
             const saved = await this.annotator.saveAnnotation(result);
+            this.navigator.emit(ReaderEvent.BookmarkCreated, annotation);
             await this.showBookmarks();
             await this.drawBookmarks();
             return new Promise<Annotation>((resolve) => resolve(saved));
           } else {
             const saved = await this.annotator.saveAnnotation(annotation);
+            this.navigator.emit(ReaderEvent.BookmarkCreated, annotation);
             await this.showBookmarks();
             await this.drawBookmarks();
             return new Promise<Annotation>((resolve) => resolve(saved));

--- a/src/modules/TTS/TTSModule2.ts
+++ b/src/modules/TTS/TTSModule2.ts
@@ -18,6 +18,7 @@
  */
 
 import { ReaderModule } from "../ReaderModule";
+import { ReaderEvent } from "../../utils/Events";
 import { AnnotationMarker } from "../../model/Locator";
 import {
   TTSModuleAPI,
@@ -223,9 +224,11 @@ export class TTSModule2 implements ReaderModule {
   }
 
   cancel(api: boolean = true) {
-    if (api) {
+    if (api && this.speaking) {
       if (this.api?.stopped) this.api?.stopped();
-      this.navigator.emit("readaloud.stopped", "stopped");
+      this.navigator.emit(ReaderEvent.ReadAloudStopped, "stopped", {
+        locator: this.navigator.currentLocator(),
+      });
     }
     this.userScrolled = false;
     this.speaking = false;
@@ -253,7 +256,9 @@ export class TTSModule2 implements ReaderModule {
     }
 
     if (this.api?.started) this.api?.started();
-    this.navigator.emit("readaloud.started", "started");
+    this.navigator.emit(ReaderEvent.ReadAloudStarted, "started", {
+      locator: this.navigator.currentLocator(),
+    });
 
     const self = this;
     this.userScrolled = false;
@@ -445,14 +450,18 @@ export class TTSModule2 implements ReaderModule {
               log.log("utterance ended");
               self.highlighter.doneSpeaking();
               self.api?.finished();
-              self.navigator.emit("readaloud.finished", "finished");
+              self.navigator.emit(ReaderEvent.ReadAloudFinished, "finished", {
+                locator: this.navigator.currentLocator(),
+              });
             }
           }
         } else {
           log.log("utterance ended");
           self.highlighter.doneSpeaking();
           self.api?.finished();
-          self.navigator.emit("readaloud.finished", "finished");
+          self.navigator.emit(ReaderEvent.ReadAloudFinished, "finished", {
+            locator: this.navigator.currentLocator(),
+          });
         }
       };
     }
@@ -596,7 +605,9 @@ export class TTSModule2 implements ReaderModule {
     this.scrollPartial = true;
     this.cancel(false);
     if (this.api?.started) this.api?.started();
-    this.navigator.emit("readaloud.started", "started");
+    this.navigator.emit(ReaderEvent.ReadAloudStarted, "started", {
+      locator: this.navigator.currentLocator(),
+    });
 
     let self = this;
     let iframe = document.querySelector(
@@ -673,7 +684,9 @@ export class TTSModule2 implements ReaderModule {
   speakPause() {
     if (window.speechSynthesis.speaking) {
       if (this.api?.paused) this.api?.paused();
-      this.navigator.emit("readaloud.paused", "paused");
+      this.navigator.emit(ReaderEvent.ReadAloudPaused, "paused", {
+        locator: this.navigator.currentLocator(),
+      });
       this.userScrolled = false;
       window.speechSynthesis.pause();
       this.speaking = false;
@@ -688,7 +701,9 @@ export class TTSModule2 implements ReaderModule {
   speakResume() {
     if (window.speechSynthesis.speaking) {
       if (this.api?.resumed) this.api?.resumed();
-      this.navigator.emit("readaloud.resumed", "resumed");
+      this.navigator.emit(ReaderEvent.ReadAloudResumed, "resumed", {
+        locator: this.navigator.currentLocator(),
+      });
       this.userScrolled = false;
       window.speechSynthesis.resume();
       this.speaking = true;

--- a/src/modules/citation/CitationModule.ts
+++ b/src/modules/citation/CitationModule.ts
@@ -22,6 +22,7 @@ import { IFrameNavigator } from "../../navigator/IFrameNavigator";
 import { ReaderModule } from "../ReaderModule";
 import { TextHighlighter } from "../highlight/TextHighlighter";
 import log from "loglevel";
+import { ReaderEvent } from "../../utils/Events";
 
 export enum CitationStyle {
   Chicago = 0,
@@ -123,8 +124,13 @@ export default class CitationModule implements ReaderModule {
       tmp.innerHTML = textToClipboard;
       const plainText = tmp.textContent ?? tmp.innerText ?? textToClipboard;
       navigator.clipboard.writeText(plainText).then(
-        () =>
-          this.api?.citationCreated("The text was copied to the clipboard!"),
+        () => {
+          this.api?.citationCreated("The text was copied to the clipboard!");
+          this.navigator.emit(
+            ReaderEvent.CitationCreated,
+            "The text was copied to the clipboard!"
+          );
+        },
         () => this.legacyCopyToClipboard(textToClipboard)
       );
     } else {
@@ -152,8 +158,16 @@ export default class CitationModule implements ReaderModule {
     document.body.removeChild(forExecElement);
     if (success) {
       this.api?.citationCreated("The text was copied to the clipboard!");
+      this.navigator.emit(
+        ReaderEvent.CitationCreated,
+        "The text was copied to the clipboard!"
+      );
     } else {
       this.api?.citationFailed("Your browser doesn't allow clipboard access!");
+      this.navigator.emit(
+        ReaderEvent.CitationFailed,
+        "Your browser doesn't allow clipboard access!"
+      );
     }
   }
 

--- a/src/modules/consumption/ConsumptionModule.ts
+++ b/src/modules/consumption/ConsumptionModule.ts
@@ -1,6 +1,7 @@
 import { ReaderModule } from "../ReaderModule";
 import { Publication } from "../../model/Publication";
 import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { ReaderEvent } from "../../utils/Events";
 import log from "loglevel";
 import { Locator } from "../../model/Locator";
 
@@ -111,6 +112,7 @@ export class ConsumptionModule implements ReaderModule {
   }
   trackAction(locator: Locator, action: Action) {
     this.api?.actionTracked(locator, action);
+    this.navigator.emit(ReaderEvent.ActionTracked, { locator, action });
   }
   startReadingSession(locator: Locator) {
     if (this.firstReadingLocator && this.lastReadingLocator) {
@@ -224,6 +226,7 @@ export class ConsumptionModule implements ReaderModule {
 
     if (this.currSeconds === this.properties.idleTimeout) {
       this.api?.idleSince(this.currSeconds);
+      this.navigator.emit(ReaderEvent.IdleSince, this.currSeconds);
       if (this.startResearchTimer !== undefined) {
         this.updateResearchSession();
       } else {

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -32,6 +32,7 @@ import {
   SelectionMenuItem,
 } from "./common/highlight";
 import { ISelectionInfo } from "./common/selection";
+import { ReaderEvent } from "../../utils/Events";
 import { getClientRectsNoOverlap, IRectSimple } from "./common/rect-utils";
 import {
   convertRangeInfo,
@@ -1119,20 +1120,26 @@ export class TextHighlighter {
     if (!this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = true;
       if (this.api?.selectionMenuOpen) this.api?.selectionMenuOpen();
-      this.navigator.emit("toolbox.opened", "opened");
+      const doc = this.navigator.iframes[0].contentDocument;
+      const sel = doc ? this.dom(doc.body)?.getSelection() : null;
+      const text = sel && !sel.isCollapsed ? sel.toString() : undefined;
+      this.navigator.emit(ReaderEvent.ToolboxOpened, "opened", { text });
+      if (text && sel) {
+        if (this.api?.selection) this.api.selection(text, sel);
+        this.navigator.emit(ReaderEvent.TextSelected, { text, selection: sel });
+      }
     }
   }, 100);
   selectionMenuClosed = debounce(() => {
     if (this.isSelectionMenuOpen) {
       this.isSelectionMenuOpen = false;
       if (this.api?.selectionMenuClose) this.api?.selectionMenuClose();
-      this.navigator.emit("toolbox.closed", "closed");
+      this.navigator.emit(ReaderEvent.ToolboxClosed, "closed");
     }
   }, 100);
 
-  selection = debounce((text, selection) => {
-    if (this.api?.selection) this.api?.selection(text, selection);
-  }, 100);
+  /** @deprecated Selection callback now fires from selectionMenuOpened */
+  selection = debounce((_text: string, _selection: any) => {}, 100);
 
   toolboxPlacement() {
     let range = this.dom(
@@ -1388,6 +1395,10 @@ export class TextHighlighter {
                                   self.navigator.annotationModule?.api
                                     ?.addCommentToAnnotation(anno)
                                     .then((result) => {
+                                      self.navigator.emit(
+                                        ReaderEvent.AnnotationCommentAdded,
+                                        result
+                                      );
                                       self.navigator.annotationModule
                                         ?.updateAnnotation(result)
                                         .then(async () => {
@@ -2364,6 +2375,7 @@ export class TextHighlighter {
           this.navigator.annotationModule?.api
             ?.selectedAnnotation(anno)
             .then(async () => {});
+          this.navigator.emit(ReaderEvent.AnnotationSelected, anno);
         }
 
         if (anno?.id) {
@@ -2396,6 +2408,10 @@ export class TextHighlighter {
                 self.navigator.annotationModule?.api
                   ?.addCommentToAnnotation(anno)
                   .then((result) => {
+                    self.navigator.emit(
+                      ReaderEvent.AnnotationCommentAdded,
+                      result
+                    );
                     self.navigator.annotationModule
                       ?.updateAnnotation(result)
                       .then(async () => {
@@ -2499,7 +2515,11 @@ export class TextHighlighter {
               lodash.omit(result, "callbacks"),
               lodash.omit(foundHighlight, "definition")
             );
-            this.navigator.emit("definition.click", result, foundHighlight);
+            this.navigator.emit(
+              ReaderEvent.DefinitionClick,
+              result,
+              foundHighlight
+            );
           }
         }
       }
@@ -3265,6 +3285,7 @@ export class TextHighlighter {
           self.navigator.annotationModule?.api
             ?.selectedAnnotation(anno)
             .then(async () => {});
+          self.navigator.emit(ReaderEvent.AnnotationSelected, anno);
         } else if (self.navigator.rights.enableBookmarks) {
           anno = (await self.navigator.bookmarkModule?.getAnnotationByID(
             highlight.id

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -21,6 +21,7 @@ import { Publication } from "../../model/Publication";
 import { IFrameNavigator } from "../../navigator/IFrameNavigator";
 import { ReaderModule } from "../ReaderModule";
 import { Link } from "../../model/Link";
+import { ReaderEvent } from "../../utils/Events";
 import { MediaOverlayNode } from "../../model/v3/MediaOverlayNode";
 import {
   MediaOverlaySettings,
@@ -64,6 +65,7 @@ export class MediaOverlayModule implements ReaderModule {
   private audioElement: HTMLMediaElement;
   settings: MediaOverlaySettings;
   private properties: MediaOverlayModuleProperties;
+  private api?: MediaOverlayModuleAPI;
   private play: HTMLLinkElement = HTMLUtilities.findElement(
     document,
     "#menu-button-play"
@@ -92,6 +94,7 @@ export class MediaOverlayModule implements ReaderModule {
       config.settings,
       config as MediaOverlayModuleProperties
     );
+    mediaOverlay.api = config.api;
     mediaOverlay.start();
     return mediaOverlay;
   }
@@ -184,10 +187,32 @@ export class MediaOverlayModule implements ReaderModule {
         await this.playLink();
       } else {
         if (this.settings.autoTurn && this.settings.playing) {
-          if (this.audioElement) {
-            await this.audioElement.pause();
+          const currentLink = this.currentLinks[this.currentLinkIndex];
+          const nextLink = currentLink
+            ? this.publication.getNextSpineItem(
+                this.publication.getAbsoluteHref(currentLink.href)
+              )
+            : undefined;
+          if (nextLink) {
+            if (this.audioElement) {
+              await this.audioElement.pause();
+            }
+            this.navigator.nextResource();
+          } else {
+            // End of book — no more resources
+            await this.stopReadAloud();
+            if (this.api?.finished) this.api.finished();
+            this.navigator.emit(ReaderEvent.ReadAlongFinished, "finished", {
+              href: this.currentLinks[this.currentLinkIndex]?.href,
+            });
           }
-          this.navigator.nextResource();
+        } else if (this.settings.playing) {
+          // autoTurn off, no audio on this page
+          await this.stopReadAloud();
+          if (this.api?.stopped) this.api.stopped();
+          this.navigator.emit(ReaderEvent.ReadAlongStopped, "stopped", {
+            href: this.currentLinks[this.currentLinkIndex]?.href,
+          });
         } else {
           await this.stopReadAloud();
         }
@@ -323,6 +348,10 @@ export class MediaOverlayModule implements ReaderModule {
       if (this.play) this.play.style.display = "none";
       if (this.pause) this.pause.style.removeProperty("display");
       this.bindClickHandler();
+      if (this.api?.started) this.api.started();
+      this.navigator.emit(ReaderEvent.ReadAlongStarted, "started", {
+        href: this.currentLinks[this.currentLinkIndex]?.href,
+      });
     }
   }
   async stopReadAloud() {
@@ -342,6 +371,10 @@ export class MediaOverlayModule implements ReaderModule {
       this.audioElement.pause();
       if (this.play) this.play.style.removeProperty("display");
       if (this.pause) this.pause.style.display = "none";
+      if (this.api?.paused) this.api.paused();
+      this.navigator.emit(ReaderEvent.ReadAlongPaused, "paused", {
+        href: this.currentLinks[this.currentLinkIndex]?.href,
+      });
     }
   }
   async resumeReadAloud() {
@@ -350,6 +383,10 @@ export class MediaOverlayModule implements ReaderModule {
       await this.audioElement.play();
       if (this.play) this.play.style.display = "none";
       if (this.pause) this.pause.style.removeProperty("display");
+      if (this.api?.resumed) this.api.resumed();
+      this.navigator.emit(ReaderEvent.ReadAlongResumed, "resumed", {
+        href: this.currentLinks[this.currentLinkIndex]?.href,
+      });
     }
   }
 
@@ -478,8 +515,29 @@ export class MediaOverlayModule implements ReaderModule {
         } else {
           this.audioElement.pause();
           if (this.settings.autoTurn && this.settings.playing) {
-            this.audioElement.pause();
-            this.navigator.nextResource();
+            const currentLink = this.currentLinks[this.currentLinkIndex];
+            const nextLink = currentLink
+              ? this.publication.getNextSpineItem(
+                  this.publication.getAbsoluteHref(currentLink.href)
+                )
+              : undefined;
+            if (nextLink) {
+              this.navigator.nextResource();
+            } else {
+              // End of book
+              this.stopReadAloud();
+              if (this.api?.finished) this.api.finished();
+              this.navigator.emit(ReaderEvent.ReadAlongFinished, "finished", {
+                href: this.currentLinks[this.currentLinkIndex]?.href,
+              });
+            }
+          } else if (this.settings.playing) {
+            // autoTurn off, chapter ended
+            this.stopReadAloud();
+            if (this.api?.stopped) this.api.stopped();
+            this.navigator.emit(ReaderEvent.ReadAlongStopped, "stopped", {
+              href: this.currentLinks[this.currentLinkIndex]?.href,
+            });
           } else {
             this.stopReadAloud();
           }
@@ -896,9 +954,11 @@ export class MediaOverlayModule implements ReaderModule {
     log.log("moHighlight:  ## " + id);
     // Get active class from metadata: try @readium/shared method, then otherMetadata, then settings fallback
     let classActive =
-      (this.publication.metadata as any)?.getMediaOverlay?.()?.activeClass
-      ?? this.publication.metadata?.otherMetadata?.["media-overlay"]?.["active-class"]
-      ?? this.settings.color;
+      (this.publication.metadata as any)?.getMediaOverlay?.()?.activeClass ??
+      this.publication.metadata?.otherMetadata?.["media-overlay"]?.[
+        "active-class"
+      ] ??
+      this.settings.color;
     const styleAttr =
       this.navigator.iframes[0].contentDocument?.documentElement.getAttribute(
         "style"
@@ -945,10 +1005,7 @@ export class MediaOverlayModule implements ReaderModule {
       }
       this.pid = id;
     }
-    if (
-      current &&
-      !this.publication.isFixedLayout
-    ) {
+    if (current && !this.publication.isFixedLayout) {
       current.scrollIntoView({
         block: "center",
         behavior: "smooth",

--- a/src/modules/search/DefinitionsModule.ts
+++ b/src/modules/search/DefinitionsModule.ts
@@ -27,6 +27,7 @@ import {
 } from "../highlight/TextHighlighter";
 import * as lodash from "lodash";
 import { searchDocDomSeek } from "./searchWithDomSeek";
+import { ReaderEvent } from "../../utils/Events";
 import { HighlightType, IHighlight } from "../highlight/common/highlight";
 import debounce from "debounce";
 import { ISelectionInfo } from "../highlight/common/selection";
@@ -177,7 +178,9 @@ export class DefinitionsModule implements ReaderModule {
     await this.searchAndPaint(item, async (result) => {
       if (this.api?.success) {
         this.api?.success(lodash.omit(item, "callbacks"), result);
-        this.navigator.emit("definition.success", result);
+        if (result && result.length > 0) {
+          this.navigator.emit(ReaderEvent.DefinitionSuccess, result);
+        }
 
         if (this.api?.visible) {
           result.forEach((highlight) => {
@@ -196,7 +199,11 @@ export class DefinitionsModule implements ReaderModule {
                       lodash.omit(item, "callbacks"),
                       lodash.omit(highlight, "definition")
                     );
-                    this.navigator.emit("definition.visible", item, highlight);
+                    this.navigator.emit(
+                      ReaderEvent.DefinitionVisible,
+                      item,
+                      highlight
+                    );
                   }
                 });
               },

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -18,6 +18,7 @@
  */
 
 import Navigator from "./Navigator";
+import { ReaderEvent } from "../utils/Events";
 import Annotator from "../store/Annotator";
 import { Publication } from "../model/Publication";
 import EventHandler, {
@@ -539,7 +540,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
       if (dir === "ltr") this.spreads.style.flexDirection = "row";
       this.keyboardEventHandler.rtl = dir === "rtl";
       if (this.api?.direction) this.api?.direction(dir);
-      this.emit("direction", dir);
+      this.emit(ReaderEvent.Direction, dir);
     }
   }
 
@@ -1479,12 +1480,12 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             "(" + this.currentChapterLink.title + ")";
         if (this.api?.chapterInfo)
           this.api.chapterInfo(this.currentChapterLink.title);
-        this.emit("chapterinfo", this.currentChapterLink.title);
+        this.emit(ReaderEvent.ChapterInfo, this.currentChapterLink.title);
       } else {
         if (this.chapterTitle)
           this.chapterTitle.innerHTML = "(Current Chapter)";
         if (this.api?.chapterInfo) this.api.chapterInfo(undefined);
-        this.emit("chapterinfo", undefined);
+        this.emit(ReaderEvent.ChapterInfo, undefined);
       }
 
       await this.injectInjectablesIntoIframeHead(iframe);
@@ -1716,6 +1717,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             ? new Error(e)
             : new Error("An unknown error occurred in the IFrameNavigator.");
       this.api.onError(trueError);
+      this.emit(ReaderEvent.Error, trueError);
     } else {
       // otherwise just display the standard error UI
       if (this.errorMessage) this.errorMessage.style.display = "block";
@@ -2247,7 +2249,11 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
       this.mediaOverlayModule !== undefined &&
       this.hasMediaOverlays
     ) {
+      const wasPlaying = this.mediaOverlayModule.settings.playing;
       this.mediaOverlayModule?.stopReadAloud();
+      if (wasPlaying) {
+        this.emit(ReaderEvent.ReadAlongStopped, "stopped");
+      }
     }
   }
 
@@ -2519,7 +2525,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
   private handleClickThrough(event: MouseEvent | TouchEvent) {
     if (this.api?.clickThrough) this.api?.clickThrough(event);
-    this.emit("click", event);
+    this.emit(ReaderEvent.Click, event);
   }
 
   private handleInternalLink(event: MouseEvent | TouchEvent) {
@@ -2776,7 +2782,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           if (this.api?.positionInfo) {
             this.api.positionInfo(locator);
           }
-          this.emit("positioninfo", locator);
+          this.emit(ReaderEvent.PositionInfo, locator);
         }
       } else {
         if (this.chapterPosition) this.chapterPosition.innerHTML = "";
@@ -2878,7 +2884,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
   private handleKeydownFallthrough(event: KeyboardEvent | undefined): void {
     if (this.api?.keydownFallthrough) this.api?.keydownFallthrough(event);
-    this.emit("keydown", event);
+    this.emit(ReaderEvent.KeyDown, event);
   }
 
   private hideView(): void {
@@ -3076,12 +3082,12 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
               "(" + this.currentChapterLink.title + ")";
           if (this.api?.chapterInfo)
             this.api.chapterInfo(this.currentChapterLink.title);
-          this.emit("chapterinfo", this.currentChapterLink.title);
+          this.emit(ReaderEvent.ChapterInfo, this.currentChapterLink.title);
         } else {
           if (this.chapterTitle)
             this.chapterTitle.innerHTML = "(Current Chapter)";
           if (this.api?.chapterInfo) this.api.chapterInfo(undefined);
-          this.emit("chapterinfo", undefined);
+          this.emit(ReaderEvent.ChapterInfo, undefined);
         }
         await this.updatePositionInfo();
       } else {
@@ -3170,7 +3176,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           if (this.previousChapterTopAnchorElement)
             this.previousChapterTopAnchorElement.style.display = "none";
           if (this.api?.resourceFitsScreen) this.api?.resourceFitsScreen();
-          this.emit("resource.fits");
+          this.emit(ReaderEvent.ResourceFits, {
+            href: this.currentChapterLink.href,
+          });
         } else {
           this.settings.isPaginated().then((paginated) => {
             if (!paginated) {
@@ -3222,13 +3230,19 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
   checkResourcePosition = debounce(() => {
     if (this.view?.atStart() && this.view?.atEnd()) {
       if (this.api?.resourceFitsScreen) this.api?.resourceFitsScreen();
-      this.emit("resource.fits");
+      this.emit(ReaderEvent.ResourceFits, {
+        href: this.currentChapterLink.href,
+      });
     } else if (this.view?.atEnd()) {
       if (this.api?.resourceAtEnd) this.api?.resourceAtEnd();
-      this.emit("resource.end");
+      this.emit(ReaderEvent.ResourceEnd, {
+        href: this.currentChapterLink.href,
+      });
     } else if (this.view?.atStart()) {
       if (this.api?.resourceAtStart) this.api?.resourceAtStart();
-      this.emit("resource.start");
+      this.emit(ReaderEvent.ResourceStart, {
+        href: this.currentChapterLink.href,
+      });
     }
   }, 200);
 
@@ -3275,17 +3289,25 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         this.view?.padOddColumns?.();
         if (this.view?.atStart() && this.view?.atEnd()) {
           if (this.api?.resourceFitsScreen) this.api?.resourceFitsScreen();
-          this.emit("resource.fits");
+          this.emit(ReaderEvent.ResourceFits, {
+            href: this.currentChapterLink.href,
+          });
         } else if (this.view?.atEnd()) {
           if (this.api?.resourceAtEnd) this.api?.resourceAtEnd();
-          this.emit("resource.end");
+          this.emit(ReaderEvent.ResourceEnd, {
+            href: this.currentChapterLink.href,
+          });
         } else if (this.view?.atStart()) {
           if (this.api?.resourceAtStart) this.api?.resourceAtStart();
-          this.emit("resource.start");
+          this.emit(ReaderEvent.ResourceStart, {
+            href: this.currentChapterLink.href,
+          });
         }
       }
       if (this.api?.resourceReady) this.api?.resourceReady();
-      this.emit("resource.ready");
+      this.emit(ReaderEvent.ResourceReady, {
+        href: this.currentChapterLink.href,
+      });
     }, 150);
   }
 
@@ -3363,6 +3385,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             log.log("save last reading position", position);
             this.annotator.saveLastReadingPosition(position);
           }
+          this.emit(ReaderEvent.LocationChanged, position);
           if (this.consumptionModule) {
             this.consumptionModule.continueReadingSession(position);
           }

--- a/src/navigator/PDFNavigator.ts
+++ b/src/navigator/PDFNavigator.ts
@@ -20,6 +20,7 @@
 import debounce from "debounce";
 import EventEmitter from "eventemitter3";
 import Navigator from "./Navigator";
+import { ReaderEvent } from "../utils/Events";
 import { UserSettings } from "../model/user-settings/UserSettings";
 import { Publication } from "../model/Publication";
 import { Bookmark, Locator, ReadingPosition } from "../model/Locator";
@@ -255,10 +256,14 @@ export class PDFNavigator extends EventEmitter implements Navigator {
         // Emit boundary events so integrators get the same signals as EPUB.
         if (this.atStart()) {
           this.api?.resourceAtStart?.();
-          this.emit("resource.start");
+          this.emit(ReaderEvent.ResourceStart, {
+            href: this.publication.readingOrder[0]?.href,
+          });
         } else if (this.atEnd()) {
           this.api?.resourceAtEnd?.();
-          this.emit("resource.end");
+          this.emit(ReaderEvent.ResourceEnd, {
+            href: this.publication.readingOrder[0]?.href,
+          });
         }
       }
     );
@@ -270,7 +275,9 @@ export class PDFNavigator extends EventEmitter implements Navigator {
         this._numPages = pagesCount;
         this.hideLoading();
         this.api?.resourceReady?.();
-        this.emit("resource.ready");
+        this.emit(ReaderEvent.ResourceReady, {
+          href: this.publication.readingOrder[0]?.href,
+        });
         // Restore saved position once — on the very first document load only.
         if (!this._positionRestored) {
           this._positionRestored = true;
@@ -410,7 +417,7 @@ export class PDFNavigator extends EventEmitter implements Navigator {
       const error = err instanceof Error ? err : new Error(String(err));
       console.error("PDFNavigator: failed to load document", url, error);
       this.api?.onError?.(error);
-      this.emit("resource.error", error);
+      this.emit(ReaderEvent.ResourceError, error);
     }
   }
 
@@ -993,6 +1000,7 @@ export class PDFNavigator extends EventEmitter implements Navigator {
     } else {
       this.annotator.saveLastReadingPosition(position);
     }
+    this.emit(ReaderEvent.LocationChanged, position);
   }
 
   private async restoreLastReadingPosition(): Promise<void> {

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -18,7 +18,6 @@
  */
 import { Annotation, Bookmark, Locator } from "./model/Locator";
 import { Publication } from "./model/Publication";
-import { Manifest } from "@readium/shared";
 import { UserSettingsIncrementable } from "./model/user-settings/UserProperties";
 import { UserSettings } from "./model/user-settings/UserSettings";
 import { AnnotationModule } from "./modules/AnnotationModule";
@@ -64,7 +63,9 @@ import { ConsumptionModule } from "./modules/consumption/ConsumptionModule";
  * Dynamically import PDFNavigator to avoid loading pdfjs-dist in SSR/Node.
  * pdfjs-dist references browser-only APIs (DOMMatrix, canvas) at import time.
  */
-let _PDFNavigatorClass: (typeof import("./navigator/PDFNavigator"))["PDFNavigator"] | undefined;
+let _PDFNavigatorClass:
+  | (typeof import("./navigator/PDFNavigator"))["PDFNavigator"]
+  | undefined;
 async function loadPDFNavigator() {
   if (!_PDFNavigatorClass) {
     const mod = await import("./navigator/PDFNavigator");
@@ -245,14 +246,10 @@ export default class D2Reader {
         initialUserSettings: initialConfig.userSettings,
         headerMenu: headerMenu,
         api: initialConfig.api,
-        injectables:
-          publication.isFixedLayout
-            ? initialConfig.injectablesFixed
-            : initialConfig.injectables,
-        layout:
-          publication.isFixedLayout
-            ? "fixed"
-            : "reflowable",
+        injectables: publication.isFixedLayout
+          ? initialConfig.injectablesFixed
+          : initialConfig.injectables,
+        layout: publication.isFixedLayout ? "fixed" : "reflowable",
       });
 
       // Highlighter
@@ -413,10 +410,9 @@ export default class D2Reader {
         tts: initialConfig.tts,
         sample: initialConfig.sample,
         requestConfig: initialConfig.requestConfig,
-        injectables:
-          publication.isFixedLayout
-            ? (initialConfig.injectablesFixed ?? [])
-            : initialConfig.injectables,
+        injectables: publication.isFixedLayout
+          ? (initialConfig.injectablesFixed ?? [])
+          : initialConfig.injectables,
         attributes: initialConfig.attributes,
         services: initialConfig.services,
         highlighter,

--- a/src/utils/Events.ts
+++ b/src/utils/Events.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2018-2026 DITA (AM Consulting LLC)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Developed on behalf of: DITA (AM Consulting LLC)
+ */
+
+import {
+  Locator,
+  ReadingPosition,
+  Bookmark,
+  Annotation,
+} from "../model/Locator";
+
+/**
+ * Typed event names for the R2D2BC reader.
+ *
+ * Both navigators and modules emit these events through the EventEmitter.
+ * Integrators can listen via:
+ *   reader.addEventListener("resource.ready", handler)
+ *   reader.addEventListener(ReaderEvent.ResourceReady, handler)
+ *
+ * All existing string event names are preserved for backwards compatibility.
+ */
+
+// ── Navigator Events ───────────────────────────────────────────
+
+export const ReaderEvent = {
+  // Resource lifecycle
+  ResourceReady: "resource.ready",
+  ResourceStart: "resource.start",
+  ResourceEnd: "resource.end",
+  ResourceFits: "resource.fits",
+  ResourceError: "resource.error",
+
+  // Navigation info
+  Direction: "direction",
+  ChapterInfo: "chapterinfo",
+  PositionInfo: "positioninfo",
+  LocationChanged: "location.changed",
+
+  // User interaction
+  Click: "click",
+  KeyDown: "keydown",
+
+  // Error
+  Error: "error",
+
+  // TTS / Read Aloud
+  ReadAloudStarted: "readaloud.started",
+  ReadAloudStopped: "readaloud.stopped",
+  ReadAloudPaused: "readaloud.paused",
+  ReadAloudResumed: "readaloud.resumed",
+  ReadAloudFinished: "readaloud.finished",
+
+  // Media Overlays / Read Along
+  ReadAlongStarted: "readalong.started",
+  ReadAlongStopped: "readalong.stopped",
+  ReadAlongPaused: "readalong.paused",
+  ReadAlongResumed: "readalong.resumed",
+  ReadAlongFinished: "readalong.finished",
+
+  // Bookmarks
+  BookmarkCreated: "bookmark.created",
+  BookmarkDeleted: "bookmark.deleted",
+
+  // Annotations
+  AnnotationCreated: "annotation.created",
+  AnnotationDeleted: "annotation.deleted",
+  AnnotationUpdated: "annotation.updated",
+  AnnotationSelected: "annotation.selected",
+  AnnotationCommentAdded: "annotation.comment.added",
+
+  // Text selection / Toolbox
+  ToolboxOpened: "toolbox.opened",
+  ToolboxClosed: "toolbox.closed",
+  TextSelected: "text.selected",
+
+  // Definitions
+  DefinitionSuccess: "definition.success",
+  DefinitionClick: "definition.click",
+  DefinitionVisible: "definition.visible",
+
+  // Citation
+  CitationCreated: "citation.created",
+  CitationFailed: "citation.failed",
+
+  // Content Protection
+  InspectDetected: "inspect.detected",
+
+  // Consumption tracking
+  ActionTracked: "consumption.action",
+  IdleSince: "consumption.idle",
+} as const;
+
+export type ReaderEventName = (typeof ReaderEvent)[keyof typeof ReaderEvent];
+
+// ── Event Payloads ─────────────────────────────────────────────
+
+export interface ReaderEventMap {
+  // Resource lifecycle
+  [ReaderEvent.ResourceReady]: void;
+  [ReaderEvent.ResourceStart]: void;
+  [ReaderEvent.ResourceEnd]: void;
+  [ReaderEvent.ResourceFits]: void;
+  [ReaderEvent.ResourceError]: Error;
+
+  // Navigation info
+  [ReaderEvent.Direction]: string;
+  [ReaderEvent.ChapterInfo]: string | undefined;
+  [ReaderEvent.PositionInfo]: Locator;
+  [ReaderEvent.LocationChanged]: ReadingPosition;
+
+  // User interaction
+  [ReaderEvent.Click]: MouseEvent | TouchEvent;
+  [ReaderEvent.KeyDown]: KeyboardEvent;
+
+  // Error
+  [ReaderEvent.Error]: Error;
+
+  // TTS
+  [ReaderEvent.ReadAloudStarted]: string;
+  [ReaderEvent.ReadAloudStopped]: string;
+  [ReaderEvent.ReadAloudPaused]: string;
+  [ReaderEvent.ReadAloudResumed]: string;
+  [ReaderEvent.ReadAloudFinished]: string;
+
+  // Media Overlays
+  [ReaderEvent.ReadAlongStarted]: string;
+  [ReaderEvent.ReadAlongStopped]: string;
+  [ReaderEvent.ReadAlongPaused]: string;
+  [ReaderEvent.ReadAlongResumed]: string;
+  [ReaderEvent.ReadAlongFinished]: string;
+
+  // Bookmarks
+  [ReaderEvent.BookmarkCreated]: Bookmark;
+  [ReaderEvent.BookmarkDeleted]: Bookmark;
+
+  // Annotations
+  [ReaderEvent.AnnotationCreated]: Annotation;
+  [ReaderEvent.AnnotationDeleted]: Annotation;
+  [ReaderEvent.AnnotationUpdated]: Annotation;
+  [ReaderEvent.AnnotationSelected]: Annotation;
+  [ReaderEvent.AnnotationCommentAdded]: Annotation;
+
+  // Text selection
+  [ReaderEvent.ToolboxOpened]: string;
+  [ReaderEvent.ToolboxClosed]: string;
+  [ReaderEvent.TextSelected]: { text: string; selection: any };
+
+  // Definitions
+  [ReaderEvent.DefinitionSuccess]: any;
+  [ReaderEvent.DefinitionClick]: { result: any; highlight: any };
+  [ReaderEvent.DefinitionVisible]: { item: any; highlight: any };
+
+  // Citation
+  [ReaderEvent.CitationCreated]: string;
+  [ReaderEvent.CitationFailed]: string;
+
+  // Content Protection
+  [ReaderEvent.InspectDetected]: void;
+
+  // Consumption
+  [ReaderEvent.ActionTracked]: { locator: Locator; action: any };
+  [ReaderEvent.IdleSince]: number;
+}

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1138,6 +1138,9 @@
                     selectionMenuClose: function() {
                         console.log("selectionMenuClose");
                     },
+                    selection: function() {
+                      console.log("selection through callback");
+                    },
                 },
                 preventScrollOnSelection: true,
             },
@@ -1338,7 +1341,9 @@
                 }
             },
             injectables: injectables,
-            injectablesFixed: [],
+            injectablesFixed: [
+                { type: 'style', url: defined_origin + '/viewer/injectables/style/style.css' },
+            ],
             userSettings: userSettings,
             useLocalStorage: true, // true = uses local storage, false = uses session storage (default)
             useStorageType: "local", // local, session or memory !! use either this or useLocalStorage,
@@ -1349,39 +1354,150 @@
             console.log("D2reader instance ready", instance);
             d2reader = instance;
 
-            instance.addEventListener("readalong.started", (detail) => {
-                console.log("Something in the annotations has changed. ");
-                console.log("listener " + detail);
-            });
-            instance.addEventListener("readaloud.started", (detail) => {
-                console.log("listener " + detail);
-            });
-            instance.addEventListener("readaloud.stopped", (detail) => {
-                console.log("listener " + detail);
-            });
-            instance.addEventListener("readaloud.paused", (detail) => {
-                console.log("listener " + detail);
-            });
-            instance.addEventListener("readaloud.resumed", (detail) => {
-                console.log("listener " + detail);
+            // ── Resource lifecycle ──────────────────────────────────
+            instance.addEventListener("resource.ready", () => {
+                console.log("[EVENT] resource.ready");
             });
             instance.addEventListener("resource.start", () => {
-                console.log("listener start");
+                console.log("[EVENT] resource.start");
             });
             instance.addEventListener("resource.end", () => {
-                console.log("listener end");
+                console.log("[EVENT] resource.end");
             });
             instance.addEventListener("resource.fits", () => {
-                console.log("listener fits");
+                console.log("[EVENT] resource.fits");
             });
-            instance.addEventListener("resource.ready", () => {
-                console.log("listener ready");
+            instance.addEventListener("resource.error", (error) => {
+                console.log("[EVENT] resource.error", error);
+            });
+
+            // ── Navigation info ───────────────────────────────────
+            instance.addEventListener("direction", (dir) => {
+                console.log("[EVENT] direction:", dir);
+            });
+            instance.addEventListener("chapterinfo", (title) => {
+                console.log("[EVENT] chapterinfo:", title);
+            });
+            instance.addEventListener("positioninfo", (locator) => {
+                console.log("[EVENT] positioninfo:", locator);
+            });
+            instance.addEventListener("location.changed", (position) => {
+                console.log("[EVENT] location.changed:", position);
+            });
+
+            // ── User interaction ──────────────────────────────────
+            instance.addEventListener("click", (event) => {
+                console.log("[EVENT] click:", event.type);
             });
             instance.addEventListener("keydown", (event) => {
-                console.log("keydown: " + event.key);
+                console.log("[EVENT] keydown:", event.key);
             });
-            instance.addEventListener("click", (event) => {
-                console.log("click through: " + event.detail);
+
+            // ── Error ─────────────────────────────────────────────
+            instance.addEventListener("error", (error) => {
+                console.log("[EVENT] error:", error);
+            });
+
+            // ── TTS / Read Aloud ──────────────────────────────────
+            instance.addEventListener("readaloud.started", (detail) => {
+                console.log("[EVENT] readaloud.started:", detail);
+            });
+            instance.addEventListener("readaloud.stopped", (detail) => {
+                console.log("[EVENT] readaloud.stopped:", detail);
+            });
+            instance.addEventListener("readaloud.paused", (detail) => {
+                console.log("[EVENT] readaloud.paused:", detail);
+            });
+            instance.addEventListener("readaloud.resumed", (detail) => {
+                console.log("[EVENT] readaloud.resumed:", detail);
+            });
+            instance.addEventListener("readaloud.finished", (detail) => {
+                console.log("[EVENT] readaloud.finished:", detail);
+            });
+
+            // ── Media Overlays / Read Along ───────────────────────
+            instance.addEventListener("readalong.started", (detail) => {
+                console.log("[EVENT] readalong.started:", detail);
+            });
+            instance.addEventListener("readalong.stopped", (detail) => {
+                console.log("[EVENT] readalong.stopped:", detail);
+            });
+            instance.addEventListener("readalong.paused", (detail) => {
+                console.log("[EVENT] readalong.paused:", detail);
+            });
+            instance.addEventListener("readalong.resumed", (detail) => {
+                console.log("[EVENT] readalong.resumed:", detail);
+            });
+            instance.addEventListener("readalong.finished", (detail) => {
+                console.log("[EVENT] readalong.finished:", detail);
+            });
+
+            // ── Bookmarks ─────────────────────────────────────────
+            instance.addEventListener("bookmark.created", (bookmark) => {
+                console.log("[EVENT] bookmark.created:", bookmark);
+            });
+            instance.addEventListener("bookmark.deleted", (bookmark) => {
+                console.log("[EVENT] bookmark.deleted:", bookmark);
+            });
+
+            // ── Annotations ───────────────────────────────────────
+            instance.addEventListener("annotation.created", (annotation) => {
+                console.log("[EVENT] annotation.created:", annotation);
+            });
+            instance.addEventListener("annotation.deleted", (annotation) => {
+                console.log("[EVENT] annotation.deleted:", annotation);
+            });
+            instance.addEventListener("annotation.updated", (annotation) => {
+                console.log("[EVENT] annotation.updated:", annotation);
+            });
+            instance.addEventListener("annotation.selected", (annotation) => {
+                console.log("[EVENT] annotation.selected:", annotation);
+            });
+            instance.addEventListener("annotation.comment.added", (annotation) => {
+                console.log("[EVENT] annotation.comment.added:", annotation);
+            });
+
+            // ── Text selection / Toolbox ──────────────────────────
+            instance.addEventListener("toolbox.opened", (detail) => {
+                console.log("[EVENT] toolbox.opened:", detail);
+            });
+            instance.addEventListener("toolbox.closed", (detail) => {
+                console.log("[EVENT] toolbox.closed:", detail);
+            });
+            instance.addEventListener("text.selected", (detail) => {
+                console.log("[EVENT] text.selected:", detail);
+            });
+
+            // ── Definitions ───────────────────────────────────────
+            instance.addEventListener("definition.success", (result) => {
+                console.log("[EVENT] definition.success:", result);
+            });
+            instance.addEventListener("definition.click", (result, highlight) => {
+                console.log("[EVENT] definition.click:", result, highlight);
+            });
+            instance.addEventListener("definition.visible", (item, highlight) => {
+                console.log("[EVENT] definition.visible:", item, highlight);
+            });
+
+            // ── Citation ──────────────────────────────────────────
+            instance.addEventListener("citation.created", (message) => {
+                console.log("[EVENT] citation.created:", message);
+            });
+            instance.addEventListener("citation.failed", (message) => {
+                console.log("[EVENT] citation.failed:", message);
+            });
+
+            // ── Content Protection ────────────────────────────────
+            instance.addEventListener("inspect.detected", () => {
+                console.log("[EVENT] inspect.detected");
+            });
+
+            // ── Consumption ───────────────────────────────────────
+            instance.addEventListener("consumption.action", (detail) => {
+                console.log("[EVENT] consumption.action:", detail);
+            });
+            instance.addEventListener("consumption.idle", (seconds) => {
+                console.log("[EVENT] consumption.idle:", seconds);
             });
 
         }).catch(error => {


### PR DESCRIPTION
## Summary
- **Typed event constants** — `ReaderEvent` constants replace raw strings for all 33 events
- **Enriched payloads** — `ReaderEventMap` types with locator, href, text, and other useful data
- **Dual system** — callbacks for two-way communication (integrator returns data), events for one-way notifications
- **MO API callbacks wired** — `started`, `stopped`, `finished`, `paused` callbacks were defined but never called
- **All emits use constants** — no raw string event names anywhere

### Bug Fixes
- `text.selected` flooding — moved to `selectionMenuOpened` with guard
- Spurious `readaloud.stopped` / `readalong.stopped` — only emit when actually active
- `definition.success` spam — only emit when results found

See [CHANGES-v3-event-system.md](docs/v3/CHANGES-v3-event-system.md) for full details.

## Test plan
- [x] All event listeners fire with correct payloads
- [x] MO callbacks (started/stopped/finished/paused) fire at correct times
- [x] TTS callbacks fire correctly
- [x] text.selected fires once per selection (not dozens)
- [x] No spurious stopped/finished events when not active
- [x] Existing callback-based integrations still work