### PR TITLE
v3 workstream 3.2: Navigator refactor

### DIFF
--- a/CHANGES-v3-navigator-refactor.md
+++ b/CHANGES-v3-navigator-refactor.md
@@ -39,6 +39,12 @@ Branch: `feature/v3-navigator-refactor` (based on `feature/v3-event-system`)
 - Applied for both FXL (spread flex order) and reflowable (keyboard RTL flag + direction event)
 - CSS `writing-mode` support deferred to workstream 3.6
 
+### FXL spread positioning
+- Checks `properties.page` (left/right/center) from manifest before falling back to index parity
+- Respects `rendition:spread: "none"` — forces single-page display for books that declare it
+- Center pages (`page-spread-center`) skip loading the second iframe
+- FXL-specific preferences (spread mode, fit mode, zoom persistence) deferred to workstream 3.5
+
 ## Bug Fixes
 
 ### MO click-to-jump after FXL page turn

--- a/CHANGES-v3-navigator-refactor.md
+++ b/CHANGES-v3-navigator-refactor.md
@@ -1,0 +1,92 @@
+# CHANGES — v3 Workstream 3.2: Navigator Refactor
+
+Branch: `feature/v3-navigator-refactor` (based on `feature/v3-event-system`)
+
+## Breaking Changes
+
+### IFrameNavigator → EpubNavigator
+- Class renamed from `IFrameNavigator` to `EpubNavigator`
+- File renamed from `src/navigator/IFrameNavigator.ts` to `src/navigator/EpubNavigator.ts`
+- Config interface renamed from `IFrameNavigatorConfig` to `EpubNavigatorConfig`
+- **Migration:** `IFrameNavigator` and `IFrameNavigatorConfig` are exported as deprecated aliases — existing code continues to work but should be updated
+
+### Navigation methods return `Promise<void>`
+- `nextPage()`, `previousPage()`, `nextResource()`, `previousResource()`, `navigate()` now return `Promise<void>` instead of `void`
+- Existing callers that don't `await` are unaffected (fire-and-forget still works)
+
+## New Features
+
+### VisualNavigator abstract class
+- New base class: `Navigator` → `VisualNavigator` → `EpubNavigator` / `PDFNavigator`
+- `NavigatorFeature` typed constants for capability queries (replaces `instanceof` checks)
+- `supports(feature)` method — check capabilities at runtime without coupling to class hierarchy
+- `goLeft()` / `goRight()` — RTL-aware spatial navigation
+
+### FXL zoom/pan (#899)
+- `zoomIn()` / `zoomOut()` / `fitToPage()` — exposed on both `EpubNavigator` and `D2Reader`
+- Scrollable viewport: zoom container architecture with `margin: auto` centering and `overflow: auto` scrolling
+- `activateHand()` / `deactivateHand()` — GrabToPan hand tool for panning (same API as PDF)
+- Auto-activates pan when zoomed beyond fit, deactivates on fit-to-page
+- Keyboard shortcuts: `+` / `-` / `0` keys for FXL books (attached to document + iframe docs)
+- Pan overlay captures mouse events over iframes without blocking clicks at fit-to-page
+- Dynamic scroll container bounds: adapts to timeline (left) and info-bottom (bottom) if present
+- Drop shadow preserved with `box-sizing: content-box` for MUI/border-box compatibility
+- Viewer: zoom/pan buttons shown for FXL books with active state sync
+
+### Spine page-progression-direction
+- `setDirection("auto")` now resolves from `readingProgression` and `rendition:spread-direction` metadata
+- Falls back to `ltr` when auto and no metadata specified
+- Applied for both FXL (spread flex order) and reflowable (keyboard RTL flag + direction event)
+- CSS `writing-mode` support deferred to workstream 3.6
+
+## Bug Fixes
+
+### MO click-to-jump after FXL page turn
+- Media overlay click handler was only bound once in `startReadAloud()`
+- After page turn, new iframe content documents lost the handlers
+- Now re-binds after each `resourceReady` when MO is playing
+
+### MO injectable fix
+- Fixed FXL media overlay CSS injectable URL
+
+## Architecture Changes
+
+### BookView decoupled from navigator
+- New `BookViewHost` interface replaces direct `EpubNavigator` back-reference
+- `BookView`, `ReflowableBookView`, `FixedBookView` use `host: BookViewHost` instead of `navigator: EpubNavigator`
+- Enables BookView reuse without navigator dependency
+
+### Capability query system
+- `NavigatorFeature` constants: `Search`, `Annotations`, `Bookmarks`, `TTS`, `MediaOverlays`, `ContentProtection`, `Timeline`, `PageBreaks`, `Definitions`, `LineFocus`, `History`, `Citations`, `Consumption`, `Zoom`
+- `supports(feature: NavigatorFeatureName): boolean` — checks rights + module existence
+- Navigator `instanceof` checks in `reader.ts` replaced with `supports()` or direct no-op calls
+
+## Deferred
+
+- **FXL search & annotations (#870)** — deferred to workstream 3.7 (TextHighlighter refactor)
+- **Predictive spine prefetching** — moved to workstream 3.4 (Fetcher/Resource)
+- **CSS writing-mode / vertical text (#1013)** — deferred to workstream 3.6 (ReadiumCSS v2)
+
+## Migration Guide
+
+```typescript
+// Before
+import { IFrameNavigator } from "@d-i-t-a/reader";
+
+// After
+import { EpubNavigator } from "@d-i-t-a/reader";
+// Or keep using IFrameNavigator (deprecated alias, still works)
+
+// Capability check — before
+if (navigator instanceof IFrameNavigator && navigator.searchModule) { ... }
+
+// Capability check — after
+if (navigator.supports("search")) { ... }
+
+// FXL zoom
+d2reader.zoomIn();
+d2reader.zoomOut();
+d2reader.fitToPage();
+d2reader.activateHand();   // enable pan
+d2reader.deactivateHand(); // disable pan
+```

--- a/injectables/style/mo.css
+++ b/injectables/style/mo.css
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2026 DITA (AM Consulting LLC)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Developed on behalf of: DITA
+ */
+
+:root[style] .r2-mo-active,
+:root .r2-mo-active {
+    background-color: yellow !important;
+    color: black !important;
+}
+
+.orangetext {
+    color: rgb(255, 165, 0) !important;
+}
+.redtext {
+    color: rgb(255,0,0) !important;
+}
+.bluetext {
+    color: rgb(0,0,255) !important;
+}
+.purpletext {
+    color: rgb(102,0,153) !important;
+}
+.greentext {
+    color: rgb(0,102,0) !important;
+}
+.graytext {
+    color:  rgb(85,85,85) !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15811,7 +15811,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
       "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -15946,7 +15945,6 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16109,7 +16107,6 @@
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
       "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16803,7 +16800,6 @@
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -17064,7 +17060,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20466,7 +20461,6 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-stream-zip": {
@@ -23907,7 +23901,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -24228,6 +24221,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vue": {
@@ -25927,7 +25938,8 @@
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
           "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "semver": {
           "version": "6.3.1",
@@ -31809,7 +31821,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/@ladjs/consolidate/-/consolidate-1.0.4.tgz",
           "integrity": "sha512-ErvBg5acSqns86V/xW7gjqqnBBs6thnpMB0gGc3oM7WHsV8PWrnBtKI6dumHDT3UT/zEOfGzp7dmSFqWoCXKWQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@parcel/codeframe": {
           "version": "2.16.4",
@@ -33073,7 +33086,8 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
       "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@typescript-eslint/type-utils": {
       "version": "8.57.1",
@@ -33527,7 +33541,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.14.0",
@@ -33878,8 +33893,7 @@
     "baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "dev": true
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -33987,7 +34001,6 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -34074,8 +34087,7 @@
     "caniuse-lite": {
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
-      "dev": true
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -34570,8 +34582,7 @@
     "electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
-      "dev": true
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -34784,8 +34795,7 @@
     "escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -34905,7 +34915,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -34993,7 +35004,8 @@
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
           "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ms": {
           "version": "2.1.2",
@@ -35238,7 +35250,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
       "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.11.1",
@@ -37091,8 +37104,7 @@
     "node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "dev": true
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="
     },
     "node-stream-zip": {
       "version": "1.15.0",
@@ -37496,7 +37508,8 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parcel-runtime-precache-manifest/-/parcel-runtime-precache-manifest-0.0.5.tgz",
       "integrity": "sha512-SJaggUvINkN332gY6DCmqQ6iKcG5aTHE6XxJnrN935RRCIoOUH9Fxh0uft9Hg4GIkowO8xZDvcAZAIEFrMkvpg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "parent-module": {
       "version": "1.0.1",
@@ -39095,7 +39108,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.3",
@@ -39146,7 +39160,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-node": {
       "version": "10.9.2",
@@ -39489,7 +39504,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -39605,7 +39619,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.3",
@@ -39627,6 +39642,14 @@
             "rollup": "^4.43.0",
             "tinyglobby": "^0.2.15"
           }
+        },
+        "yaml": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+          "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.8",
+  "version": "3.0.0-alpha.9",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.9",
+  "version": "3.0.0-alpha.10",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type { ReaderEventName, ReaderEventMap } from "./utils/Events";
 
 export { NavigatorFeature } from "./navigator/VisualNavigator";
 export type { NavigatorFeatureName } from "./navigator/VisualNavigator";
+export { EpubNavigator, IFrameNavigator } from "./navigator/EpubNavigator";
 
 // ─── Navigator / Config ─────────────────────────────────────────────────────
 
@@ -59,7 +60,9 @@ export type {
   SampleRead,
   PublicationServices,
   InitialAnnotations,
-} from "./navigator/IFrameNavigator";
+  EpubNavigatorConfig,
+  IFrameNavigatorConfig,
+} from "./navigator/EpubNavigator";
 
 // ─── User Settings ───────────────────────────────────────────────────────────
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,11 @@ export {
 export { ReaderEvent } from "./utils/Events";
 export type { ReaderEventName, ReaderEventMap } from "./utils/Events";
 
+// ─── Navigator ──────────────────────────────────────────────────────────────
+
+export { NavigatorFeature } from "./navigator/VisualNavigator";
+export type { NavigatorFeatureName } from "./navigator/VisualNavigator";
+
 // ─── Navigator / Config ─────────────────────────────────────────────────────
 
 export type {

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -607,7 +607,7 @@ export class UserSettings implements IUserSettings {
           HTMLUtilities.findElement(document, "#root") ||
           document.documentElement;
         const body = HTMLUtilities.findElement(html, "body");
-        if (this.view?.navigator.publication.isReflowable) {
+        if (this.view?.host?.isReflowable()) {
           // Apply font size
           if (await this.getProperty(ReadiumCSS.FONT_SIZE_KEY)) {
             html.style.setProperty(
@@ -653,7 +653,7 @@ export class UserSettings implements IUserSettings {
               ?.toString() ?? null
           );
         }
-        if (this.view?.navigator.publication.isReflowable) {
+        if (this.view?.host?.isReflowable()) {
           // Apply text alignment
           if (await this.getProperty(ReadiumCSS.TEXT_ALIGNMENT_KEY)) {
             if (
@@ -797,18 +797,18 @@ export class UserSettings implements IUserSettings {
           if (body) HTMLUtilities.setAttr(body, "data-viewer-theme", "day");
         }
 
-        if (this.view?.navigator.publication.isFixedLayout) {
+        if (this.view?.host?.isFixedLayout()) {
           if (await this.getProperty(ReadiumCSS.DIRECTION_KEY)) {
             let value =
               this.userProperties
                 .getByRef(ReadiumCSS.DIRECTION_REF)
                 ?.toString() ?? null;
             html.style.setProperty(ReadiumCSS.DIRECTION_KEY, value);
-            this.view.navigator.setDirection(value);
+            this.view.host?.setDirection(value);
           }
         }
 
-        if (this.view?.navigator.publication.isReflowable) {
+        if (this.view?.host?.isReflowable()) {
           // Apply font family
           if (await this.getProperty(ReadiumCSS.FONT_FAMILY_KEY)) {
             html.style.setProperty(

--- a/src/model/user-settings/UserSettings.ts
+++ b/src/model/user-settings/UserSettings.ts
@@ -30,7 +30,7 @@ import {
 import { ReadiumCSS } from "./ReadiumCSS";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import { addEventListenerOptional } from "../../utils/EventHandler";
-import { Injectable, NavigatorAPI } from "../../navigator/IFrameNavigator";
+import { Injectable, NavigatorAPI } from "../../navigator/EpubNavigator";
 import ReflowableBookView from "../../views/ReflowableBookView";
 import FixedBookView from "../../views/FixedBookView";
 import BookView from "../../views/BookView";

--- a/src/model/v3/Publication.ts
+++ b/src/model/v3/Publication.ts
@@ -23,7 +23,7 @@ import {
   GetContentBytesLength,
   RequestConfig,
   SampleRead,
-} from "../../navigator/IFrameNavigator";
+} from "../../navigator/EpubNavigator";
 
 /**
  * Convert a @readium/shared Link into an R2D2BC Link.

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -19,7 +19,7 @@
 
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 import Annotator, { AnnotationType } from "../store/Annotator";
-import { IFrameNavigator, ReaderRights } from "../navigator/IFrameNavigator";
+import { EpubNavigator, ReaderRights } from "../navigator/EpubNavigator";
 import { Publication } from "../model/Publication";
 import {
   TextHighlighter,
@@ -70,7 +70,7 @@ export interface AnnotationModuleConfig extends AnnotationModuleProperties {
   headerMenu?: HTMLElement | null;
   rights: Partial<ReaderRights>;
   publication: Publication;
-  initialAnnotations?: import("../navigator/IFrameNavigator").InitialAnnotations;
+  initialAnnotations?: import("../navigator/EpubNavigator").InitialAnnotations;
   api?: AnnotationModuleAPI;
   highlighter: TextHighlighter;
 }
@@ -83,8 +83,8 @@ export class AnnotationModule implements ReaderModule {
   private commentGutter?: HTMLDivElement | null;
   private readonly headerMenu?: HTMLElement | null;
   private readonly highlighter?: TextHighlighter;
-  private readonly initialAnnotations?: import("../navigator/IFrameNavigator").InitialAnnotations;
-  navigator: IFrameNavigator;
+  private readonly initialAnnotations?: import("../navigator/EpubNavigator").InitialAnnotations;
+  navigator: EpubNavigator;
   properties?: AnnotationModuleProperties;
   api?: AnnotationModuleAPI;
   activeAnnotationMarkerId?: string;

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -19,7 +19,7 @@
 
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 import Annotator, { AnnotationType } from "../store/Annotator";
-import { IFrameNavigator, ReaderRights } from "../navigator/IFrameNavigator";
+import { EpubNavigator, ReaderRights } from "../navigator/EpubNavigator";
 import { Publication } from "../model/Publication";
 import { ReaderModule } from "./ReaderModule";
 import { addEventListenerOptional } from "../utils/EventHandler";
@@ -59,7 +59,7 @@ export interface BookmarkModuleConfig extends BookmarkModuleProperties {
   headerMenu?: HTMLElement | null;
   rights: Partial<ReaderRights>;
   publication: Publication;
-  initialAnnotations?: import("../navigator/IFrameNavigator").InitialAnnotations;
+  initialAnnotations?: import("../navigator/EpubNavigator").InitialAnnotations;
   properties?: BookmarkModuleProperties;
   api?: BookmarkModuleAPI;
 }
@@ -71,8 +71,8 @@ export class BookmarkModule implements ReaderModule {
   private bookmarksView: HTMLDivElement;
   private sideNavSectionBookmarks: HTMLElement;
   private readonly headerMenu?: HTMLElement | null;
-  private readonly initialAnnotations?: import("../navigator/IFrameNavigator").InitialAnnotations;
-  navigator: IFrameNavigator;
+  private readonly initialAnnotations?: import("../navigator/EpubNavigator").InitialAnnotations;
+  navigator: EpubNavigator;
   private readonly properties: BookmarkModuleProperties;
   private readonly api?: BookmarkModuleAPI;
 

--- a/src/modules/TTS/TTSModule2.ts
+++ b/src/modules/TTS/TTSModule2.ts
@@ -32,7 +32,7 @@ import {
   removeEventListenerOptional,
 } from "../../utils/EventHandler";
 import sanitize from "sanitize-html";
-import { IFrameNavigator, ReaderRights } from "../../navigator/IFrameNavigator";
+import { EpubNavigator, ReaderRights } from "../../navigator/EpubNavigator";
 import { TextHighlighter } from "../highlight/TextHighlighter";
 import { HighlightType, IHighlight } from "../highlight/common/highlight";
 import { uniqueCssSelector } from "../highlight/renderer/common/cssselector2";
@@ -50,7 +50,7 @@ export class TTSModule2 implements ReaderModule {
   private clean: any;
   private rights: Partial<ReaderRights>;
   private readonly highlighter: TextHighlighter;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private body: any;
   private hasEventListener: boolean = false;
   private readonly headerMenu?: HTMLElement | null;

--- a/src/modules/TTS/TTSSettings.ts
+++ b/src/modules/TTS/TTSSettings.ts
@@ -27,7 +27,7 @@ import {
   JSONable,
 } from "../../model/user-settings/UserProperties";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
-import { ReaderRights } from "../../navigator/IFrameNavigator";
+import { ReaderRights } from "../../navigator/EpubNavigator";
 import { TextHighlighter } from "../highlight/TextHighlighter";
 import { addEventListenerOptional } from "../../utils/EventHandler";
 import log from "loglevel";

--- a/src/modules/citation/CitationModule.ts
+++ b/src/modules/citation/CitationModule.ts
@@ -18,7 +18,7 @@
  */
 
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import { TextHighlighter } from "../highlight/TextHighlighter";
 import log from "loglevel";
@@ -80,7 +80,7 @@ const EMPTY: CitationTuple = ["", "", ""];
 
 export default class CitationModule implements ReaderModule {
   private publication: Publication;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private properties: CitationModuleProperties;
   private readonly highlighter?: TextHighlighter;
   api?: CitationModuleAPI;

--- a/src/modules/consumption/ConsumptionModule.ts
+++ b/src/modules/consumption/ConsumptionModule.ts
@@ -1,6 +1,6 @@
 import { ReaderModule } from "../ReaderModule";
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderEvent } from "../../utils/Events";
 import log from "loglevel";
 import { Locator } from "../../model/Locator";
@@ -42,7 +42,7 @@ export interface ConsumptionModuleConfig extends ConsumptionModuleProperties {
 }
 
 export class ConsumptionModule implements ReaderModule {
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private publication: Publication;
   private properties: ConsumptionModuleProperties;
   api?: ConsumptionModuleAPI;

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -41,7 +41,7 @@ import {
 import { uniqueCssSelector } from "./renderer/common/cssselector2";
 import { Annotation, AnnotationMarker } from "../../model/Locator";
 import { icons, iconTemplateColored } from "../../utils/IconLib";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { TTSModule2 } from "../TTS/TTSModule2";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import * as lodash from "lodash";
@@ -150,7 +150,7 @@ export interface TextHighlighterConfig extends TextHighlighterProperties {
 
 export class TextHighlighter {
   private options: any;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   layerSettings: LayerSettings;
   private lastSelectedHighlight?: number = undefined;
   properties: TextHighlighterProperties;

--- a/src/modules/history/HistoryModule.ts
+++ b/src/modules/history/HistoryModule.ts
@@ -17,7 +17,7 @@
  * Licensed to: Allvit under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import {
@@ -41,7 +41,7 @@ export interface HistoryModuleConfig extends HistoryModuleProperties {
 
 export class HistoryModule implements ReaderModule {
   readonly annotator: Annotator | null;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private readonly headerMenu?: HTMLElement | null;
   private publication: Publication;
   private properties: HistoryModuleProperties;

--- a/src/modules/linefocus/LineFocusModule.ts
+++ b/src/modules/linefocus/LineFocusModule.ts
@@ -18,7 +18,7 @@
  */
 
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import {
   TextHighlighter,
@@ -59,7 +59,7 @@ export interface LineFocusModuleConfig extends LineFocusModuleProperties {
 export default class LineFocusModule implements ReaderModule {
   properties: LineFocusModuleProperties;
   api?: LineFocusModuleAPI;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private highlighter: TextHighlighter;
   private hasEventListener: boolean = false;
 

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -18,7 +18,7 @@
  */
 
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import { Link } from "../../model/Link";
 import { ReaderEvent } from "../../utils/Events";
@@ -61,7 +61,7 @@ export interface MediaOverlayModuleConfig extends MediaOverlayModuleProperties {
 
 export class MediaOverlayModule implements ReaderModule {
   private publication: Publication;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private audioElement: HTMLMediaElement;
   settings: MediaOverlaySettings;
   private properties: MediaOverlayModuleProperties;

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -220,7 +220,7 @@ export class MediaOverlayModule implements ReaderModule {
     }
   }
 
-  private bindClickHandler() {
+  bindClickHandler() {
     this.unbindClickHandler();
     const handler = this.handleContentClick.bind(this);
     this.clickHandler = handler;

--- a/src/modules/pagebreak/PageBreakModule.ts
+++ b/src/modules/pagebreak/PageBreakModule.ts
@@ -17,7 +17,7 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import { uniqueCssSelector } from "../highlight/renderer/common/cssselector2";
 import { convertRange } from "../highlight/renderer/iframe/selection";
@@ -45,7 +45,7 @@ export interface PageBreakModuleConfig extends PageBreakModuleProperties {
 }
 
 export class PageBreakModule implements ReaderModule {
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private readonly headerMenu?: HTMLElement | null;
   private publication: Publication;
   private properties: PageBreakModuleProperties;

--- a/src/modules/positions/TimelineModule.ts
+++ b/src/modules/positions/TimelineModule.ts
@@ -18,7 +18,7 @@
  */
 
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import { addEventListenerOptional } from "../../utils/EventHandler";
@@ -32,7 +32,7 @@ export interface TimelineModuleConfig {
 
 export class TimelineModule implements ReaderModule {
   private publication: Publication;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private timelineContainer: HTMLDivElement;
   private positionSlider: HTMLInputElement;
 

--- a/src/modules/protection/ContentProtectionModule.ts
+++ b/src/modules/protection/ContentProtectionModule.ts
@@ -19,7 +19,7 @@
 
 import { ReaderModule } from "../ReaderModule";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import {
   addEventListenerOptional,
   removeEventListenerOptional,
@@ -73,7 +73,7 @@ interface ContentProtectionRect {
 
 export class ContentProtectionModule implements ReaderModule {
   private rects: Array<ContentProtectionRect>;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   properties?: ContentProtectionModuleProperties;
   private hasEventListener: boolean = false;
   private isHacked: boolean = false;

--- a/src/modules/sampleread/SampleReadEventHandler.ts
+++ b/src/modules/sampleread/SampleReadEventHandler.ts
@@ -18,11 +18,11 @@
  */
 
 import debounce from "debounce";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 
 export default class SampleReadEventHandler {
-  navigator: IFrameNavigator;
-  constructor(navigator: IFrameNavigator) {
+  navigator: EpubNavigator;
+  constructor(navigator: EpubNavigator) {
     this.navigator = navigator;
   }
 

--- a/src/modules/search/DefinitionsModule.ts
+++ b/src/modules/search/DefinitionsModule.ts
@@ -17,7 +17,7 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import {
   TextHighlighter,
@@ -66,7 +66,7 @@ export class DefinitionsModule implements ReaderModule {
   properties: DefinitionsModuleProperties;
   api?: DefinitionsModuleAPI;
   private publication: Publication;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private currentChapterPopupResult: any = [];
   private currentPopupHighlights: any = [];
   private highlighter: TextHighlighter;

--- a/src/modules/search/Popup.ts
+++ b/src/modules/search/Popup.ts
@@ -17,14 +17,14 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import sanitize from "sanitize-html";
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 
 export class Popup {
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
 
-  constructor(navigator: IFrameNavigator) {
+  constructor(navigator: EpubNavigator) {
     this.navigator = navigator;
   }
 

--- a/src/modules/search/SearchModule.ts
+++ b/src/modules/search/SearchModule.ts
@@ -19,7 +19,7 @@
 
 import * as HTMLUtilities from "../../utils/HTMLUtilities";
 import { Publication } from "../../model/Publication";
-import { IFrameNavigator } from "../../navigator/IFrameNavigator";
+import { EpubNavigator } from "../../navigator/EpubNavigator";
 import { ReaderModule } from "../ReaderModule";
 import {
   addEventListenerOptional,
@@ -60,7 +60,7 @@ export class SearchModule implements ReaderModule {
   private api?: SearchModuleAPI;
   private publication: Publication;
   private readonly headerMenu?: HTMLElement | null;
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   private searchInput: HTMLInputElement;
   private searchGo: HTMLElement;
   private currentChapterSearchResult: any = [];

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -137,7 +137,7 @@ export interface IFrameAttributes {
   /** Whether to show a drop shadow on fixed-layout spreads. Defaults to true. */
   fixedLayoutShadow?: boolean;
 }
-export interface IFrameNavigatorConfig {
+export interface EpubNavigatorConfig {
   mainElement: HTMLElement;
   headerMenu?: HTMLElement | null;
   footerMenu?: HTMLElement | null;
@@ -248,8 +248,8 @@ export interface ReaderConfig {
   workerSrc?: string;
 }
 
-/** Class that shows webpub resources in an iframe, with navigation controls outside the iframe. */
-export class IFrameNavigator extends VisualNavigator {
+/** EPUB navigator — renders spine items in iframes with navigation controls. */
+export class EpubNavigator extends VisualNavigator {
   iframes: Array<HTMLIFrameElement> = [];
 
   currentTocUrl: string | undefined;
@@ -315,7 +315,12 @@ export class IFrameNavigator extends VisualNavigator {
   // ── FXL zoom ────────────────────────────────────────────────
 
   private fxlZoomKeyHandler = (event: KeyboardEvent): void => {
-    if (/input|select|option|textarea/i.test((event.target as HTMLElement).tagName)) return;
+    if (
+      /input|select|option|textarea/i.test(
+        (event.target as HTMLElement).tagName
+      )
+    )
+      return;
     const key = event.key;
     if (key === "=" || key === "+") {
       this.zoomIn();
@@ -372,8 +377,10 @@ export class IFrameNavigator extends VisualNavigator {
       requestAnimationFrame(() => {
         if (!this.fxlScrollContainer) return;
         const isZoomed =
-          this.fxlScrollContainer.scrollWidth > this.fxlScrollContainer.clientWidth ||
-          this.fxlScrollContainer.scrollHeight > this.fxlScrollContainer.clientHeight;
+          this.fxlScrollContainer.scrollWidth >
+            this.fxlScrollContainer.clientWidth ||
+          this.fxlScrollContainer.scrollHeight >
+            this.fxlScrollContainer.clientHeight;
         if (isZoomed) {
           this.activateHand();
         } else {
@@ -512,8 +519,8 @@ export class IFrameNavigator extends VisualNavigator {
   private didInitKeyboardEventHandler: boolean = false;
 
   public static async create(
-    config: IFrameNavigatorConfig
-  ): Promise<IFrameNavigator> {
+    config: EpubNavigatorConfig
+  ): Promise<EpubNavigator> {
     const navigator = new this(
       config.settings,
       config.annotator || undefined,
@@ -680,7 +687,7 @@ export class IFrameNavigator extends VisualNavigator {
     removeEventListenerOptional(
       this.goBackButton,
       "click",
-      IFrameNavigator.goBack.bind(this)
+      EpubNavigator.goBack.bind(this)
     );
 
     removeEventListenerOptional(
@@ -1176,7 +1183,7 @@ export class IFrameNavigator extends VisualNavigator {
     addEventListenerOptional(
       this.goBackButton,
       "click",
-      IFrameNavigator.goBack.bind(this)
+      EpubNavigator.goBack.bind(this)
     );
 
     addEventListenerOptional(
@@ -1852,7 +1859,7 @@ export class IFrameNavigator extends VisualNavigator {
       const bases = iframe.contentDocument.getElementsByTagName("base");
       if (bases.length === 0) {
         head.insertBefore(
-          IFrameNavigator.createBase(this.currentChapterLink.href),
+          EpubNavigator.createBase(this.currentChapterLink.href),
           head.firstChild
         );
       }
@@ -1865,16 +1872,16 @@ export class IFrameNavigator extends VisualNavigator {
             // this.settings.addFont(injectable.fontFamily);
             this.settings.initAddedFont();
             if (!injectable.systemFont && injectable.url) {
-              const link = IFrameNavigator.createCssLink(injectable.url);
+              const link = EpubNavigator.createCssLink(injectable.url);
               head.appendChild(link);
               addLoadingInjectable(link);
             }
           } else if (injectable.r2before && injectable.url) {
-            const link = IFrameNavigator.createCssLink(injectable.url);
+            const link = EpubNavigator.createCssLink(injectable.url);
             head.insertBefore(link, head.firstChild);
             addLoadingInjectable(link);
           } else if (injectable.r2default && injectable.url) {
-            const link = IFrameNavigator.createCssLink(injectable.url);
+            const link = EpubNavigator.createCssLink(injectable.url);
             head.insertBefore(link, head.childNodes[1]);
             addLoadingInjectable(link);
           } else if (injectable.r2after && injectable.url) {
@@ -1882,16 +1889,16 @@ export class IFrameNavigator extends VisualNavigator {
               // this.settings.addAppearance(injectable.appearance);
               this.settings.initAddedAppearance();
             }
-            const link = IFrameNavigator.createCssLink(injectable.url);
+            const link = EpubNavigator.createCssLink(injectable.url);
             head.appendChild(link);
             addLoadingInjectable(link);
           } else if (injectable.url) {
-            const link = IFrameNavigator.createCssLink(injectable.url);
+            const link = EpubNavigator.createCssLink(injectable.url);
             head.appendChild(link);
             addLoadingInjectable(link);
           }
         } else if (injectable.type === "script" && injectable.url) {
-          const script = IFrameNavigator.createJavascriptLink(
+          const script = EpubNavigator.createJavascriptLink(
             injectable.url,
             injectable.async ?? false
           );
@@ -1921,7 +1928,7 @@ export class IFrameNavigator extends VisualNavigator {
           ? e
           : typeof e === "string"
             ? new Error(e)
-            : new Error("An unknown error occurred in the IFrameNavigator.");
+            : new Error("An unknown error occurred in the EpubNavigator.");
       this.api.onError(trueError);
       this.emit(ReaderEvent.Error, trueError);
     } else {
@@ -1952,7 +1959,7 @@ export class IFrameNavigator extends VisualNavigator {
         const bases = doc.getElementsByTagName("base");
         if (bases.length === 0) {
           doc.head.insertBefore(
-            IFrameNavigator.createBase(href),
+            EpubNavigator.createBase(href),
             doc.head.firstChild
           );
         }
@@ -1973,7 +1980,7 @@ export class IFrameNavigator extends VisualNavigator {
         const bases = doc.getElementsByTagName("base");
         if (bases.length === 0) {
           doc.head.insertBefore(
-            IFrameNavigator.createBase(href),
+            EpubNavigator.createBase(href),
             doc.head.firstChild
           );
         }
@@ -3738,3 +3745,9 @@ export class IFrameNavigator extends VisualNavigator {
     }
   }
 }
+
+// Backwards-compat aliases
+/** @deprecated Use EpubNavigator */
+export const IFrameNavigator = EpubNavigator;
+/** @deprecated Use EpubNavigatorConfig */
+export type IFrameNavigatorConfig = EpubNavigatorConfig;

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -713,12 +713,22 @@ export class EpubNavigator extends VisualNavigator {
 
   setDirection(direction?: string | null) {
     let dir = "";
-    if (direction === "rtl" || direction === "ltr") dir = direction;
-    if (direction === "auto")
-      dir = this.publication.metadata?.readingProgression as string;
-    if (dir) {
-      if (dir === "rtl") this.spreads.style.flexDirection = "row-reverse";
-      if (dir === "ltr") this.spreads.style.flexDirection = "row";
+    if (direction === "rtl" || direction === "ltr") {
+      dir = direction;
+    } else if (direction === "auto") {
+      // Resolve from manifest: readingProgression or rendition:spread-direction
+      dir =
+        (this.publication.metadata?.readingProgression as string) ||
+        (this.publication.metadata?.otherMetadata?.[
+          "rendition:spread-direction"
+        ] as string) ||
+        "ltr";
+    }
+    if (dir === "rtl" || dir === "ltr") {
+      if (this.publication.isFixedLayout) {
+        this.spreads.style.flexDirection =
+          dir === "rtl" ? "row-reverse" : "row";
+      }
       this.keyboardEventHandler.rtl = dir === "rtl";
       if (this.api?.direction) this.api?.direction(dir);
       this.emit(ReaderEvent.Direction, dir);
@@ -861,6 +871,20 @@ export class EpubNavigator extends VisualNavigator {
         if (this.iframes.length === 2) {
           this.iframes.pop();
         }
+        // Apply reading direction for reflowable (keyboard RTL + event)
+        let dir = "";
+        switch (this.settings.direction) {
+          case 0:
+            dir = "auto";
+            break;
+          case 1:
+            dir = "ltr";
+            break;
+          case 2:
+            dir = "rtl";
+            break;
+        }
+        this.setDirection(dir);
       }
 
       this.loadingMessage = HTMLUtilities.findElement(

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -1816,6 +1816,9 @@ export class EpubNavigator extends VisualNavigator {
         setTimeout(() => {
           if (this.mediaOverlayModule) {
             this.mediaOverlayModule.settings.resourceReady = true;
+            if (this.mediaOverlayModule.settings.playing) {
+              this.mediaOverlayModule.bindClickHandler();
+            }
           }
         }, 300);
       }, 200);

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -763,6 +763,15 @@ export class EpubNavigator extends VisualNavigator {
       if (window.matchMedia("screen and (max-width: 600px)").matches) {
         this.settings.columnCount = 1;
       }
+      // Respect rendition:spread "none" — force single page display
+      if (this.publication.isFixedLayout) {
+        const spread =
+          this.publication.metadata?.otherMetadata?.["rendition:spread"] ??
+          this.publication.metadata?.otherMetadata?.rendition?.spread;
+        if (spread === "none") {
+          this.settings.columnCount = 1;
+        }
+      }
       if (this.iframes.length === 0) {
         wrapper.style.overflow = "auto";
         let iframe = document.createElement("iframe");
@@ -1974,7 +1983,20 @@ export class EpubNavigator extends VisualNavigator {
   private precessContentForIframe() {
     const self = this;
     var index = this.publication.getSpineIndex(this.currentChapterLink.href);
-    var even: boolean = (index ?? 0) % 2 === 1;
+    // Determine spread position: use link's page property if set, else fall back to index parity
+    const spineLink =
+      index !== undefined ? this.publication.readingOrder?.[index] : undefined;
+    const pageSpread = spineLink?.properties?.page;
+    var even: boolean;
+    if (pageSpread === "left") {
+      even = true;
+    } else if (pageSpread === "right") {
+      even = false;
+    } else if (pageSpread === "center") {
+      even = true;
+    } else {
+      even = (index ?? 0) % 2 === 1;
+    }
     this.showLoadingMessageAfterDelay();
 
     this.currentSpreadLinks = {};
@@ -2061,7 +2083,10 @@ export class EpubNavigator extends VisualNavigator {
                 }
               });
             if (this.iframes.length === 2) {
-              if ((index ?? 0) < this.publication.readingOrder.length - 1) {
+              if (
+                pageSpread !== "center" &&
+                (index ?? 0) < this.publication.readingOrder.length - 1
+              ) {
                 const next = this.publication.getNextSpineItem(
                   this.currentChapterLink.href
                 );
@@ -2216,7 +2241,10 @@ export class EpubNavigator extends VisualNavigator {
               };
 
               if (this.iframes.length === 2) {
-                if ((index ?? 0) < this.publication.readingOrder.length - 1) {
+                if (
+                  pageSpread !== "center" &&
+                  (index ?? 0) < this.publication.readingOrder.length - 1
+                ) {
                   const next = this.publication.getNextSpineItem(
                     this.currentChapterLink.href
                   );
@@ -2246,7 +2274,10 @@ export class EpubNavigator extends VisualNavigator {
                 href: this.currentChapterLink.href,
               };
               if (this.iframes.length === 2) {
-                if ((index ?? 0) < this.publication.readingOrder.length - 1) {
+                if (
+                  pageSpread !== "center" &&
+                  (index ?? 0) < this.publication.readingOrder.length - 1
+                ) {
                   const next = this.publication.getNextSpineItem(
                     this.currentChapterLink.href
                   );

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -92,6 +92,7 @@ import CitationModule, {
   CitationModuleConfig,
 } from "../modules/citation/CitationModule";
 import log from "loglevel";
+import { GrabToPan } from "../utils/GrabToPan";
 import {
   ConsumptionModule,
   ConsumptionModuleConfig,
@@ -308,6 +309,129 @@ export class IFrameNavigator extends VisualNavigator {
         return !!this.rights.enableTimeline && !!this.timelineModule;
       default:
         return false;
+    }
+  }
+
+  // ── FXL zoom ────────────────────────────────────────────────
+
+  private fxlZoomKeyHandler = (event: KeyboardEvent): void => {
+    if (/input|select|option|textarea/i.test((event.target as HTMLElement).tagName)) return;
+    const key = event.key;
+    if (key === "=" || key === "+") {
+      this.zoomIn();
+    } else if (key === "-") {
+      this.zoomOut();
+    } else if (key === "0") {
+      this.fitToPage();
+    } else {
+      return;
+    }
+    event.preventDefault();
+  };
+
+  private getFxlCurrentScale(): number {
+    const match = this.spreads?.style.transform?.match(/scale\(([^)]+)\)/);
+    return match ? parseFloat(match[1]) : 1;
+  }
+
+  fitToPage(): void {
+    if (!this.publication.isFixedLayout) return;
+    this.handleResize();
+  }
+
+  zoomIn(): void {
+    if (!this.publication.isFixedLayout) return;
+    this.setFxlScale(this.getFxlCurrentScale() * 1.15);
+  }
+
+  zoomOut(): void {
+    if (!this.publication.isFixedLayout) return;
+    this.setFxlScale(this.getFxlCurrentScale() / 1.15);
+  }
+
+  private setFxlScale(newScale: number): void {
+    if (!this.spreads || !this.fxlZoomContainer) return;
+    this.spreads.style.transform = "scale(" + newScale + ")";
+    this.updateFxlZoomContainer(newScale);
+  }
+
+  private updateFxlZoomContainer(scale: number): void {
+    if (
+      !this.fxlZoomContainer ||
+      !this.fxlContentWidth ||
+      !this.fxlContentHeight
+    )
+      return;
+    this.fxlZoomContainer.style.width = this.fxlContentWidth * scale + "px";
+    this.fxlZoomContainer.style.height = this.fxlContentHeight * scale + "px";
+    this.spreads.style.width = this.fxlContentWidth + "px";
+    this.spreads.style.height = this.fxlContentHeight + "px";
+
+    // Auto-activate pan when zoomed beyond fit, deactivate when back to fit
+    if (this.fxlHandTool) {
+      requestAnimationFrame(() => {
+        if (!this.fxlScrollContainer) return;
+        const isZoomed =
+          this.fxlScrollContainer.scrollWidth > this.fxlScrollContainer.clientWidth ||
+          this.fxlScrollContainer.scrollHeight > this.fxlScrollContainer.clientHeight;
+        if (isZoomed) {
+          this.activateHand();
+        } else {
+          this.deactivateHand();
+        }
+      });
+    }
+  }
+
+  // ── FXL pan (grab-to-scroll) ──────────────────────────────
+
+  private fxlPanOverlay: HTMLDivElement;
+  private fxlHandTool: GrabToPan;
+
+  private setupFxlPan(): void {
+    const el = this.fxlScrollContainer;
+    if (!el) return;
+
+    // Transparent overlay captures mouse events over iframes.
+    // Lives inside the zoom container so it scales with the content.
+    this.fxlPanOverlay = document.createElement("div");
+    this.fxlPanOverlay.style.position = "absolute";
+    this.fxlPanOverlay.style.top = "0";
+    this.fxlPanOverlay.style.left = "0";
+    this.fxlPanOverlay.style.width = "100%";
+    this.fxlPanOverlay.style.height = "100%";
+    this.fxlPanOverlay.style.pointerEvents = "none";
+    this.fxlPanOverlay.style.zIndex = "1";
+    this.fxlZoomContainer.style.position = "relative";
+    this.fxlZoomContainer.appendChild(this.fxlPanOverlay);
+
+    // GrabToPan scrolls the scroll container, mousedown captured by overlay
+    this.fxlHandTool = new GrabToPan({ element: el });
+  }
+
+  activateHand(): void {
+    if (!this.publication.isFixedLayout) return;
+    if (this.fxlPanOverlay) {
+      this.fxlPanOverlay.style.pointerEvents = "auto";
+    }
+    this.fxlHandTool?.activate();
+    const panBtn = document.querySelector("#fxl-pan a") as HTMLElement;
+    if (panBtn) {
+      panBtn.classList.add("active");
+      panBtn.style.color = "#039be5";
+    }
+  }
+
+  deactivateHand(): void {
+    if (!this.publication.isFixedLayout) return;
+    if (this.fxlPanOverlay) {
+      this.fxlPanOverlay.style.pointerEvents = "none";
+    }
+    this.fxlHandTool?.deactivate();
+    const panBtn = document.querySelector("#fxl-pan a") as HTMLElement;
+    if (panBtn) {
+      panBtn.classList.remove("active");
+      panBtn.style.color = "";
     }
   }
 
@@ -575,6 +699,10 @@ export class IFrameNavigator extends VisualNavigator {
   }
   spreads: HTMLDivElement;
   firstSpread: HTMLDivElement;
+  private fxlScrollContainer: HTMLDivElement;
+  private fxlZoomContainer: HTMLDivElement;
+  private fxlContentWidth: number = 0;
+  private fxlContentHeight: number = 0;
 
   setDirection(direction?: string | null) {
     let dir = "";
@@ -629,11 +757,41 @@ export class IFrameNavigator extends VisualNavigator {
           this.spreads = document.createElement("div");
           this.firstSpread = document.createElement("div");
           this.spreads.style.display = "flex";
-          this.spreads.style.alignItems = "center";
-          this.spreads.style.justifyContent = "center";
+          this.spreads.style.transformOrigin = "0 0";
           this.spreads.appendChild(this.firstSpread);
           this.firstSpread.appendChild(this.iframes[0]);
-          wrapper.appendChild(this.spreads);
+
+          // Scroll container fills wrapper, handles overflow scrolling
+          this.fxlScrollContainer = document.createElement("div");
+          this.fxlScrollContainer.style.position = "absolute";
+          this.fxlScrollContainer.style.top = "0";
+          this.fxlScrollContainer.style.right = "0";
+          const timelineEl = document.getElementById("container-view-timeline");
+          this.fxlScrollContainer.style.left =
+            timelineEl && this.rights.enableTimeline ? "70px" : "0";
+          const infoBottom = document.getElementById("reader-info-bottom");
+          this.fxlScrollContainer.style.bottom = infoBottom
+            ? (this.attributes?.bottomInfoHeight ?? 40) + "px"
+            : "0";
+          this.fxlScrollContainer.style.overflow = "auto";
+          this.fxlScrollContainer.style.display = "flex";
+
+          // Sizer has visual dimensions, centered via margin: auto
+          this.fxlZoomContainer = document.createElement("div");
+          this.fxlZoomContainer.style.margin = "auto";
+          this.fxlZoomContainer.style.flexShrink = "0";
+          this.fxlZoomContainer.style.overflow = "hidden";
+          if (this.attributes?.fixedLayoutShadow !== false) {
+            this.fxlZoomContainer.style.padding = "12px";
+            this.fxlZoomContainer.style.boxSizing = "content-box";
+          }
+          this.fxlZoomContainer.appendChild(this.spreads);
+
+          this.fxlScrollContainer.appendChild(this.fxlZoomContainer);
+          wrapper.style.position = "relative";
+          wrapper.appendChild(this.fxlScrollContainer);
+          document.addEventListener("keydown", this.fxlZoomKeyHandler);
+          this.setupFxlPan();
           let dir = "";
           switch (this.settings.direction) {
             case 0:
@@ -691,11 +849,7 @@ export class IFrameNavigator extends VisualNavigator {
       }
 
       if (this.publication.isFixedLayout) {
-        const minHeight = wrapper.clientHeight;
-        // wrapper.style.height = minHeight + 40 + "px";
-        var iframeParent = this.iframes[0].parentElement
-          ?.parentElement as HTMLElement;
-        iframeParent.style.height = minHeight + 40 + "px";
+        // Zoom container dimensions are set during scale calculation
       } else {
         if (this.iframes.length === 2) {
           this.iframes.pop();
@@ -1560,6 +1714,12 @@ export class IFrameNavigator extends VisualNavigator {
           this.didInitKeyboardEventHandler = true;
         }
       }
+      if (this.publication.isFixedLayout && iframe.contentDocument) {
+        iframe.contentDocument.addEventListener(
+          "keydown",
+          this.fxlZoomKeyHandler
+        );
+      }
       if (this.view?.layout !== "fixed") {
         if (this.view?.isScrollMode()) {
           iframe.height = "0";
@@ -2210,22 +2370,20 @@ export class IFrameNavigator extends VisualNavigator {
           }
         }
 
-        var iframeParent =
-          index === 0 && this.iframes.length === 2
-            ? this.iframes[1].parentElement?.parentElement
-            : (this.iframes[0].parentElement?.parentElement as HTMLElement);
-        if (iframeParent && width) {
+        if (width) {
+          if (!this.fxlScrollContainer) return;
           const fxlMargin = this.attributes?.fixedLayoutMargin ?? 100;
+          const contentW = parseInt(width.toString().replace("px", ""));
+          const contentH = parseInt(height.toString().replace("px", ""));
           var widthRatio =
-            (parseInt(getComputedStyle(iframeParent).width) - fxlMargin) /
+            (this.fxlScrollContainer.clientWidth - fxlMargin) /
             (this.iframes.length === 2
-              ? parseInt(width.toString().replace("px", "")) * 2 + fxlMargin * 2
-              : parseInt(width.toString().replace("px", "")));
+              ? contentW * 2 + fxlMargin * 2
+              : contentW);
           var heightRatio =
-            (parseInt(getComputedStyle(iframeParent).height) - fxlMargin) /
-            parseInt(height.toString().replace("px", ""));
+            (this.fxlScrollContainer.clientHeight - fxlMargin) / contentH;
           var scale = Math.min(widthRatio, heightRatio);
-          iframeParent.style.transform = "scale(" + scale + ")";
+          this.spreads.style.transform = "scale(" + scale + ")";
           for (const iframe of this.iframes) {
             iframe.style.height = height;
             iframe.style.width = width;
@@ -2233,6 +2391,10 @@ export class IFrameNavigator extends VisualNavigator {
               iframe.parentElement.style.height = height;
             }
           }
+          this.fxlContentWidth =
+            this.iframes.length === 2 ? contentW * 2 : contentW;
+          this.fxlContentHeight = contentH;
+          this.updateFxlZoomContainer(scale);
         }
       }, 400);
     }
@@ -2655,16 +2817,7 @@ export class IFrameNavigator extends VisualNavigator {
 
     if (this.publication.isFixedLayout) {
       var index = this.publication.getSpineIndex(this.currentChapterLink.href);
-      const minHeight =
-        BrowserUtilities.getHeight() - 40 - (this.attributes?.margin ?? 0);
-
-      var iframeParent =
-        index === 0 && this.iframes.length === 2
-          ? this.iframes[1].parentElement?.parentElement
-          : (this.iframes[0].parentElement?.parentElement as HTMLElement);
-      if (iframeParent) {
-        iframeParent.style.height = minHeight + 40 + "px";
-
+      if (this.fxlScrollContainer) {
         let height, width;
         let doc;
         if (index === 0 && this.iframes?.length === 2) {
@@ -2711,26 +2864,17 @@ export class IFrameNavigator extends VisualNavigator {
         }
 
         const fxlMargin = this.attributes?.fixedLayoutMargin ?? 100;
+        const contentW = parseInt(
+          width.toString().endsWith("px") ? width?.replace("px", "") : width
+        );
+        const contentH = parseInt(height.toString().replace("px", ""));
         var widthRatio =
-          (parseInt(getComputedStyle(iframeParent).width) - fxlMargin) /
-          (this.iframes.length === 2
-            ? parseInt(
-                width.toString().endsWith("px")
-                  ? width?.replace("px", "")
-                  : width
-              ) *
-                2 +
-              fxlMargin * 2
-            : parseInt(
-                width.toString().endsWith("px")
-                  ? width?.replace("px", "")
-                  : width
-              ));
+          (this.fxlScrollContainer.clientWidth - fxlMargin) /
+          (this.iframes.length === 2 ? contentW * 2 + fxlMargin * 2 : contentW);
         var heightRatio =
-          (parseInt(getComputedStyle(iframeParent).height) - fxlMargin) /
-          parseInt(height.toString().replace("px", ""));
+          (this.fxlScrollContainer.clientHeight - fxlMargin) / contentH;
         var scale = Math.min(widthRatio, heightRatio);
-        iframeParent.style.transform = "scale(" + scale + ")";
+        this.spreads.style.transform = "scale(" + scale + ")";
 
         for (const iframe of this.iframes) {
           iframe.style.height = height;
@@ -2739,6 +2883,11 @@ export class IFrameNavigator extends VisualNavigator {
             iframe.parentElement.style.height = height;
           }
         }
+
+        this.fxlContentWidth =
+          this.iframes.length === 2 ? contentW * 2 : contentW;
+        this.fxlContentHeight = contentH;
+        this.updateFxlZoomContainer(scale);
       }
     }
 

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -17,10 +17,14 @@
  * Licensed to: Bokbasen AS and CAST under one or more contributor license agreements.
  */
 
-import Navigator from "./Navigator";
+import {
+  VisualNavigator,
+  NavigatorFeature,
+  NavigatorFeatureName,
+} from "./VisualNavigator";
 import { ReaderEvent } from "../utils/Events";
 import Annotator from "../store/Annotator";
-import { Publication } from "../model/Publication";
+import { Publication } from "../model/v3";
 import EventHandler, {
   addEventListenerOptional,
   removeEventListenerOptional,
@@ -28,12 +32,7 @@ import EventHandler, {
 import * as BrowserUtilities from "../utils/BrowserUtilities";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 import { readerError, readerLoading } from "../utils/HTMLTemplates";
-import {
-  Annotation,
-  Locations,
-  Locator,
-  ReadingPosition,
-} from "../model/Locator";
+import { Annotation, Locations, Locator, ReadingPosition } from "../model/v3";
 import {
   UserSettings,
   UserSettingsUIConfig,
@@ -69,7 +68,7 @@ import {
   MediaOverlayModule,
   MediaOverlayModuleConfig,
 } from "../modules/mediaoverlays/MediaOverlayModule";
-import { D2Link, Link } from "../model/Link";
+import { D2Link, Link } from "../model/v3";
 import SampleReadEventHandler from "../modules/sampleread/SampleReadEventHandler";
 import { ReaderModule } from "../modules/ReaderModule";
 import { TTSModuleConfig } from "../modules/TTS/TTSSettings";
@@ -85,7 +84,6 @@ import {
   DefinitionsModule,
   DefinitionsModuleConfig,
 } from "../modules/search/DefinitionsModule";
-import EventEmitter from "eventemitter3";
 import LineFocusModule, {
   LineFocusModuleConfig,
 } from "../modules/linefocus/LineFocusModule";
@@ -250,7 +248,7 @@ export interface ReaderConfig {
 }
 
 /** Class that shows webpub resources in an iframe, with navigation controls outside the iframe. */
-export class IFrameNavigator extends EventEmitter implements Navigator {
+export class IFrameNavigator extends VisualNavigator {
   iframes: Array<HTMLIFrameElement> = [];
 
   currentTocUrl: string | undefined;
@@ -272,6 +270,46 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
   historyModule?: HistoryModule;
   citationModule?: CitationModule;
   consumptionModule?: ConsumptionModule;
+
+  supports(feature: NavigatorFeatureName): boolean {
+    switch (feature) {
+      case NavigatorFeature.TTS:
+        return !!this.rights.enableTTS && !!this.ttsModule;
+      case NavigatorFeature.MediaOverlays:
+        return (
+          !!this.rights.enableMediaOverlays &&
+          !!this.mediaOverlayModule &&
+          this.hasMediaOverlays
+        );
+      case NavigatorFeature.Search:
+        return !!this.rights.enableSearch && !!this.searchModule;
+      case NavigatorFeature.Annotations:
+        return !!this.rights.enableAnnotations && !!this.annotationModule;
+      case NavigatorFeature.Bookmarks:
+        return !!this.rights.enableBookmarks && !!this.bookmarkModule;
+      case NavigatorFeature.Zoom:
+        return this.publication.isFixedLayout;
+      case NavigatorFeature.LineFocus:
+        return !!this.rights.enableLineFocus && !!this.lineFocusModule;
+      case NavigatorFeature.Definitions:
+        return !!this.rights.enableDefinitions && !!this.definitionsModule;
+      case NavigatorFeature.Citations:
+        return !!this.rights.enableCitations && !!this.citationModule;
+      case NavigatorFeature.ContentProtection:
+        return (
+          !!this.rights.enableContentProtection &&
+          !!this.contentProtectionModule
+        );
+      case NavigatorFeature.Consumption:
+        return !!this.rights.enableConsumption && !!this.consumptionModule;
+      case NavigatorFeature.History:
+        return !!this.rights.enableHistory && !!this.historyModule;
+      case NavigatorFeature.Timeline:
+        return !!this.rights.enableTimeline && !!this.timelineModule;
+      default:
+        return false;
+    }
+  }
 
   sideNavExpanded: boolean = false;
 

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -472,7 +472,15 @@ export class IFrameNavigator extends VisualNavigator {
     this.annotator = annotator;
     this.view = settings.view;
     this.view.attributes = attributes;
-    this.view.navigator = this;
+    this.view.host = {
+      checkResourcePosition: () => this.checkResourcePosition(),
+      recalculateContentProtection: (delay?: number) =>
+        this.contentProtectionModule?.recalculate(delay),
+      isContentProtectionEnabled: () => !!this.rights.enableContentProtection,
+      isFixedLayout: () => this.publication.isFixedLayout,
+      isReflowable: () => this.publication.isReflowable,
+      setDirection: (direction?: string | null) => this.setDirection(direction),
+    };
     this.eventHandler = new EventHandler(this);
     this.touchEventHandler = new TouchEventHandler(this);
     this.keyboardEventHandler = new KeyboardEventHandler(this);
@@ -907,7 +915,7 @@ export class IFrameNavigator extends VisualNavigator {
           if (menuSearch)
             menuSearch.parentElement?.style.setProperty("display", "none");
         }
-        if (menuSearch && this.view?.navigator.publication.isFixedLayout) {
+        if (menuSearch && this.publication.isFixedLayout) {
           menuSearch.parentElement?.style.setProperty("display", "none");
         }
         if (this.hasMediaOverlays) {

--- a/src/navigator/Navigator.ts
+++ b/src/navigator/Navigator.ts
@@ -70,19 +70,19 @@ interface Navigator {
 
   positions(): Locator[];
 
-  goTo(locator: Locator): void;
+  goTo(locator: Locator): void | Promise<void>;
 
-  goToPosition(value: number): void;
+  goToPosition(value: number): void | Promise<void>;
 
-  goToPage(page: number): void;
+  goToPage(page: number): void | Promise<void>;
 
-  nextResource(): void;
+  nextResource(): void | Promise<void>;
 
-  previousResource(): void;
+  previousResource(): void | Promise<void>;
 
-  nextPage(): void;
+  nextPage(): void | Promise<void>;
 
-  previousPage(): void;
+  previousPage(): void | Promise<void>;
 
   atStart?(): boolean;
 

--- a/src/navigator/Navigator.ts
+++ b/src/navigator/Navigator.ts
@@ -18,7 +18,7 @@
  */
 
 import { Locator } from "../model/Locator";
-import { IFrameAttributes } from "./IFrameNavigator";
+import { IFrameAttributes } from "./EpubNavigator";
 import { Publication } from "../model/Publication";
 import { Link } from "../model/Link";
 

--- a/src/navigator/PDFNavigator.ts
+++ b/src/navigator/PDFNavigator.ts
@@ -18,12 +18,15 @@
  */
 
 import debounce from "debounce";
-import EventEmitter from "eventemitter3";
-import Navigator from "./Navigator";
+import {
+  VisualNavigator,
+  NavigatorFeature,
+  NavigatorFeatureName,
+} from "./VisualNavigator";
 import { ReaderEvent } from "../utils/Events";
 import { UserSettings } from "../model/user-settings/UserSettings";
-import { Publication } from "../model/Publication";
-import { Bookmark, Locator, ReadingPosition } from "../model/Locator";
+import { Publication } from "../model/v3";
+import { Bookmark, Locator, ReadingPosition } from "../model/v3";
 import Annotator from "../store/Annotator";
 import Store from "../store/Store";
 import {
@@ -84,10 +87,25 @@ export enum ScaleType {
   Width = 1,
 }
 
-export class PDFNavigator extends EventEmitter implements Navigator {
+export class PDFNavigator extends VisualNavigator {
   readonly isPDF = true;
   settings: UserSettings;
   publication: Publication;
+
+  supports(feature: NavigatorFeatureName): boolean {
+    switch (feature) {
+      case NavigatorFeature.Search:
+        return true;
+      case NavigatorFeature.Annotations:
+        return true;
+      case NavigatorFeature.Zoom:
+        return true;
+      case NavigatorFeature.Bookmarks:
+        return true;
+      default:
+        return false;
+    }
+  }
 
   headerMenu?: HTMLElement | null;
   footerMenu?: HTMLElement | null;

--- a/src/navigator/PDFNavigator.ts
+++ b/src/navigator/PDFNavigator.ts
@@ -51,7 +51,7 @@ import {
   removeEventListenerOptional,
 } from "../utils/EventHandler";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
-import { NavigatorAPI } from "./IFrameNavigator";
+import { NavigatorAPI } from "./EpubNavigator";
 import { GrabToPan } from "../utils/GrabToPan";
 import { readerLoading } from "../utils/HTMLTemplates";
 

--- a/src/navigator/VisualNavigator.ts
+++ b/src/navigator/VisualNavigator.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018-2026 DITA (AM Consulting LLC)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Developed on behalf of: DITA (AM Consulting LLC)
+ */
+
+import EventEmitter from "eventemitter3";
+import Navigator from "./Navigator";
+import { Locator } from "../model/v3";
+import { Publication } from "../model/v3";
+import { Link } from "../model/v3";
+import { IFrameAttributes } from "./IFrameNavigator";
+
+/**
+ * Typed feature names for navigator capability queries.
+ */
+export const NavigatorFeature = {
+  TTS: "tts",
+  MediaOverlays: "mediaOverlays",
+  Search: "search",
+  Annotations: "annotations",
+  Bookmarks: "bookmarks",
+  Zoom: "zoom",
+  LineFocus: "lineFocus",
+  Definitions: "definitions",
+  Citations: "citations",
+  ContentProtection: "contentProtection",
+  Consumption: "consumption",
+  History: "history",
+  Timeline: "timeline",
+} as const;
+
+export type NavigatorFeatureName =
+  (typeof NavigatorFeature)[keyof typeof NavigatorFeature];
+
+/**
+ * Abstract base class for all visual navigators.
+ *
+ * Extends EventEmitter for the event system.
+ * Implements the Navigator interface for backwards compatibility.
+ *
+ * Subclasses: EpubNavigator (reflowable + FXL), PDFNavigator (PDF.js),
+ * and future navigators (AudiobookNavigator, DiViNaNavigator).
+ */
+export abstract class VisualNavigator
+  extends EventEmitter
+  implements Navigator
+{
+  abstract publication: Publication;
+
+  // ── Required implementations ──────────────────────────────────
+
+  abstract currentLocator(): Locator;
+  abstract positions(): Locator[];
+  abstract currentResource(): number | undefined;
+  abstract totalResources(): number;
+
+  abstract goTo(locator: Locator): void;
+  abstract goToPosition(value: number): void;
+  abstract goToPage(page: number): void;
+  abstract nextPage(): void;
+  abstract previousPage(): void;
+  abstract nextResource(): void;
+  abstract previousResource(): void;
+
+  abstract atStart(): boolean;
+  abstract atEnd(): boolean;
+
+  abstract tableOfContents(): Link[];
+  abstract landmarks(): Link[];
+  abstract pageList(): Link[];
+  abstract readingOrder(): Link[];
+
+  abstract stop(): void;
+
+  // ── Capability query ──────────────────────────────────────────
+
+  /**
+   * Check if this navigator supports a given feature.
+   * Replaces instanceof checks in D2Reader.
+   */
+  supports(_feature: NavigatorFeatureName): boolean {
+    return false;
+  }
+
+  // ── Default no-ops for optional features ──────────────────────
+  // Subclasses override what they support. D2Reader calls these
+  // without instanceof checks — if the navigator doesn't support
+  // the feature, the no-op runs silently.
+
+  startReadAloud(): void {}
+  stopReadAloud(): void {}
+  pauseReadAloud(): void {}
+  resumeReadAloud(): void {}
+
+  startReadAlong(): void {}
+  stopReadAlong(): void {}
+  pauseReadAlong(): void {}
+  resumeReadAlong(): void {}
+
+  hideLayer(_layer: string): void {}
+  showLayer(_layer: string): void {}
+
+  activateMarker(_id: string, _position: string): void {}
+  deactivateMarker(): void {}
+
+  snapToSelector?(_selector: string): void {}
+  applyAttributes?(_value: IFrameAttributes): void {}
+
+  mostRecentNavigatedTocItem?(): string | undefined {
+    return undefined;
+  }
+
+  // ── RTL-aware navigation ──────────────────────────────────────
+
+  /**
+   * Navigate left — respects reading progression direction.
+   * In LTR: goes to previous page. In RTL: goes to next page.
+   */
+  goLeft(): void {
+    const rtl =
+      this.publication.metadata?.readingProgression === "rtl" ||
+      this.publication.metadata?.otherMetadata?.[
+        "rendition:spread-direction"
+      ] === "rtl";
+    if (rtl) {
+      this.nextPage();
+    } else {
+      this.previousPage();
+    }
+  }
+
+  /**
+   * Navigate right — respects reading progression direction.
+   * In LTR: goes to next page. In RTL: goes to previous page.
+   */
+  goRight(): void {
+    const rtl =
+      this.publication.metadata?.readingProgression === "rtl" ||
+      this.publication.metadata?.otherMetadata?.[
+        "rendition:spread-direction"
+      ] === "rtl";
+    if (rtl) {
+      this.previousPage();
+    } else {
+      this.nextPage();
+    }
+  }
+
+  // ── Zoom (for FXL and PDF) ────────────────────────────────────
+  // Default no-ops. PDFNavigator and EpubNavigator (FXL) override.
+
+  fitToPage(): void {}
+  fitToWidth(): void {}
+  zoomIn(): void {}
+  zoomOut(): void {}
+  activateHand(): void {}
+  deactivateHand(): void {}
+}

--- a/src/navigator/VisualNavigator.ts
+++ b/src/navigator/VisualNavigator.ts
@@ -67,13 +67,13 @@ export abstract class VisualNavigator
   abstract currentResource(): number | undefined;
   abstract totalResources(): number;
 
-  abstract goTo(locator: Locator): void;
-  abstract goToPosition(value: number): void;
-  abstract goToPage(page: number): void;
-  abstract nextPage(): void;
-  abstract previousPage(): void;
-  abstract nextResource(): void;
-  abstract previousResource(): void;
+  abstract goTo(locator: Locator): void | Promise<void>;
+  abstract goToPosition(value: number): void | Promise<void>;
+  abstract goToPage(page: number): void | Promise<void>;
+  abstract nextPage(): void | Promise<void>;
+  abstract previousPage(): void | Promise<void>;
+  abstract nextResource(): void | Promise<void>;
+  abstract previousResource(): void | Promise<void>;
 
   abstract atStart(): boolean;
   abstract atEnd(): boolean;

--- a/src/navigator/VisualNavigator.ts
+++ b/src/navigator/VisualNavigator.ts
@@ -21,7 +21,7 @@ import Navigator from "./Navigator";
 import { Locator } from "../model/v3";
 import { Publication } from "../model/v3";
 import { Link } from "../model/v3";
-import { IFrameAttributes } from "./IFrameNavigator";
+import { IFrameAttributes } from "./EpubNavigator";
 
 /**
  * Typed feature names for navigator capability queries.

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -38,11 +38,11 @@ import {
   TTSSettings,
 } from "./modules/TTS/TTSSettings";
 import {
-  IFrameNavigator,
+  EpubNavigator,
   IFrameAttributes,
   ReaderConfig,
   ReaderRights,
-} from "./navigator/IFrameNavigator";
+} from "./navigator/EpubNavigator";
 import LocalAnnotator from "./store/LocalAnnotator";
 import LocalStorageStore from "./store/LocalStorageStore";
 import { findElement, findRequiredElement } from "./utils/HTMLUtilities";
@@ -392,7 +392,7 @@ export default class D2Reader {
         : undefined;
 
       // Navigator
-      const navigator = await IFrameNavigator.create({
+      const navigator = await EpubNavigator.create({
         mainElement: mainElement,
         headerMenu: headerMenu,
         footerMenu: footerMenu,

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -56,7 +56,7 @@ import LineFocusModule from "./modules/linefocus/LineFocusModule";
 import { HistoryModule } from "./modules/history/HistoryModule";
 import CitationModule from "./modules/citation/CitationModule";
 import type { PDFNavigator } from "./navigator/PDFNavigator";
-import Navigator from "./navigator/Navigator";
+import { VisualNavigator, NavigatorFeature } from "./navigator/VisualNavigator";
 import { ConsumptionModule } from "./modules/consumption/ConsumptionModule";
 
 /**
@@ -90,7 +90,7 @@ function isPDFNavigator(nav: any): nav is PDFNavigator {
 export default class D2Reader {
   private constructor(
     private readonly settings: UserSettings,
-    private readonly navigator: Navigator | IFrameNavigator | PDFNavigator,
+    private readonly navigator: VisualNavigator,
     private readonly highlighter?: TextHighlighter,
     private readonly bookmarkModule?: BookmarkModule,
     private readonly annotationModule?: AnnotationModule,
@@ -110,12 +110,7 @@ export default class D2Reader {
   ) {}
 
   addEventListener(event: string, handler: (...args: any[]) => void) {
-    if (
-      this.navigator instanceof IFrameNavigator ||
-      isPDFNavigator(this.navigator)
-    ) {
-      (this.navigator as any).addListener(event, handler);
-    }
+    this.navigator.addListener(event, handler);
   }
 
   /**
@@ -462,27 +457,19 @@ export default class D2Reader {
 
   /** Start TTS Read Aloud */
   startReadAloud = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.startReadAloud();
-    }
+    this.navigator.startReadAloud();
   };
-  /** Start TTS Read Aloud */
+  /** Stop TTS Read Aloud */
   stopReadAloud = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.stopReadAloud();
-    }
+    this.navigator.stopReadAloud();
   };
-  /** Start TTS Read Aloud */
+  /** Pause TTS Read Aloud */
   pauseReadAloud = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.pauseReadAloud();
-    }
+    this.navigator.pauseReadAloud();
   };
-  /** Start TTS Read Aloud */
+  /** Resume TTS Read Aloud */
   resumeReadAloud = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.resumeReadAloud();
-    }
+    this.navigator.resumeReadAloud();
   };
 
   /**
@@ -491,33 +478,22 @@ export default class D2Reader {
 
   /** Start Media Overlay Read Along */
   startReadAlong = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.startReadAlong();
-    }
+    this.navigator.startReadAlong();
   };
   /** Stop Media Overlay Read Along */
   stopReadAlong = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.stopReadAlong();
-    }
+    this.navigator.stopReadAlong();
   };
   /** Pause Media Overlay Read Along */
   pauseReadAlong = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.pauseReadAlong();
-    }
+    this.navigator.pauseReadAlong();
   };
   /** Resume Media Overlay Read Along */
   resumeReadAlong = () => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.resumeReadAlong();
-    }
+    this.navigator.resumeReadAlong();
   };
   get hasMediaOverlays() {
-    if (this.navigator instanceof IFrameNavigator) {
-      return this.navigator.hasMediaOverlays;
-    }
-    return false;
+    return this.navigator.publication.hasMediaOverlays ?? false;
   }
 
   /**
@@ -571,29 +547,21 @@ export default class D2Reader {
 
   /** Hide  Layer */
   hideLayer = (layer) => {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator?.hideLayer(layer)
-      : false;
+    this.navigator.hideLayer(layer);
   };
   /** Show  Layer */
   showLayer = (layer) => {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator?.showLayer(layer)
-      : false;
+    this.navigator.showLayer(layer);
   };
 
   /** Activate Marker <br>
    * Activated Marker will be used for active annotation creation */
   activateMarker = (id: string, position: string) => {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator?.activateMarker(id, position)
-      : false;
+    this.navigator.activateMarker(id, position);
   };
   /** Deactivate Marker */
   deactivateMarker = () => {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator?.deactivateMarker()
-      : false;
+    this.navigator.deactivateMarker();
   };
 
   /**
@@ -665,26 +633,17 @@ export default class D2Reader {
     return (await this.searchModule?.search(term, current)) ?? [];
   };
   goToSearchIndex = async (href: string, index: number, current: boolean) => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableSearch
-    ) {
+    if (this.navigator.supports(NavigatorFeature.Search)) {
       await this.searchModule?.goToSearchIndex(href, index, current);
     }
   };
   goToSearchID = async (href: string, index: number, current: boolean) => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableSearch
-    ) {
+    if (this.navigator.supports(NavigatorFeature.Search)) {
       await this.searchModule?.goToSearchID(href, index, current);
     }
   };
   clearSearch = async () => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableSearch
-    ) {
+    if (this.navigator.supports(NavigatorFeature.Search)) {
       await this.searchModule?.clearSearch();
     }
   };
@@ -696,9 +655,7 @@ export default class D2Reader {
     return this.navigator.currentResource();
   }
   get mostRecentNavigatedTocItem() {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator.mostRecentNavigatedTocItem()
-      : false;
+    return this.navigator.mostRecentNavigatedTocItem?.() ?? undefined;
   }
   get totalResources() {
     return this.navigator.totalResources();
@@ -747,7 +704,7 @@ export default class D2Reader {
     return incremental === "mo_rate" || incremental === "mo_volume";
   }
 
-  w; /**
+  /**
    * Used to increase anything that can be increased,
    * such as pitch, rate, volume, fontSize
    */
@@ -758,17 +715,11 @@ export default class D2Reader {
       | MediaOverlayIncrementable
   ) => {
     if (this.isTTSIncrementable(incremental)) {
-      if (
-        this.navigator instanceof IFrameNavigator &&
-        this.navigator.rights.enableTTS
-      ) {
+      if (this.navigator.supports(NavigatorFeature.TTS)) {
         await this.ttsSettings?.increase(incremental);
       }
     } else if (this.isMOIncrementable(incremental)) {
-      if (
-        this.navigator instanceof IFrameNavigator &&
-        this.navigator.rights.enableMediaOverlays
-      ) {
+      if (this.navigator.supports(NavigatorFeature.MediaOverlays)) {
         await this.mediaOverlaySettings?.increase(incremental);
       }
     } else {
@@ -787,17 +738,11 @@ export default class D2Reader {
       | MediaOverlayIncrementable
   ) => {
     if (this.isTTSIncrementable(incremental)) {
-      if (
-        this.navigator instanceof IFrameNavigator &&
-        this.navigator.rights.enableTTS
-      ) {
+      if (this.navigator.supports(NavigatorFeature.TTS)) {
         await this.ttsSettings?.decrease(incremental);
       }
     } else if (this.isMOIncrementable(incremental)) {
-      if (
-        this.navigator instanceof IFrameNavigator &&
-        this.navigator.rights.enableMediaOverlays
-      ) {
+      if (this.navigator.supports(NavigatorFeature.MediaOverlays)) {
         await this.mediaOverlaySettings?.decrease(incremental);
       }
     } else {
@@ -817,18 +762,12 @@ export default class D2Reader {
    * TTS Settings
    */
   resetTTSSettings = () => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableTTS
-    ) {
+    if (this.navigator.supports(NavigatorFeature.TTS)) {
       this.ttsSettings?.resetTTSSettings();
     }
   };
   applyTTSSettings = async (ttsSettings: Partial<ITTSUserSettings>) => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableTTS
-    ) {
+    if (this.navigator.supports(NavigatorFeature.TTS)) {
       await this.ttsSettings?.applyTTSSettings(ttsSettings);
     }
   };
@@ -841,10 +780,7 @@ export default class D2Reader {
   //   }
   // };
   applyPreferredVoice = async (value: string) => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableTTS
-    ) {
+    if (this.navigator.supports(NavigatorFeature.TTS)) {
       await this.ttsSettings?.applyPreferredVoice(value);
     }
   };
@@ -853,20 +789,14 @@ export default class D2Reader {
    * Media Overlay Settings
    */
   resetMediaOverlaySettings = async () => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableMediaOverlays
-    ) {
+    if (this.navigator.supports(NavigatorFeature.MediaOverlays)) {
       await this.mediaOverlaySettings?.resetMediaOverlaySettings();
     }
   };
   applyMediaOverlaySettings = async (
     settings: Partial<IMediaOverlayUserSettings>
   ) => {
-    if (
-      this.navigator instanceof IFrameNavigator &&
-      this.navigator.rights.enableMediaOverlays
-    ) {
+    if (this.navigator.supports(NavigatorFeature.MediaOverlays)) {
       await this.mediaOverlaySettings?.applyMediaOverlaySettings(settings);
     }
   };
@@ -891,34 +821,22 @@ export default class D2Reader {
     await this.navigator.goToPage(page);
   };
   fitToPage = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).fitToPage();
-    }
+    this.navigator.fitToPage();
   };
   fitToWidth = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).fitToWidth();
-    }
+    this.navigator.fitToWidth();
   };
   zoomIn = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).zoomIn();
-    }
+    this.navigator.zoomIn();
   };
   zoomOut = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).zoomOut();
-    }
+    this.navigator.zoomOut();
   };
   activateHand = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).activateHand();
-    }
+    this.navigator.activateHand();
   };
   deactivateHand = () => {
-    if (isPDFNavigator(this.navigator)) {
-      (this.navigator as PDFNavigator).deactivateHand();
-    }
+    this.navigator.deactivateHand();
   };
   copyToClipboard = (text) => {
     this.contentProtectionModule?.copyToClipboard(text);
@@ -936,28 +854,20 @@ export default class D2Reader {
     this.navigator.previousPage();
   };
   get atStart() {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator.atStart()
-      : false;
+    return this.navigator.atStart();
   }
   get atEnd() {
-    return this.navigator instanceof IFrameNavigator
-      ? this.navigator.atEnd()
-      : false;
+    return this.navigator.atEnd();
   }
   snapToSelector = async (selector) => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.snapToSelector(selector);
-    }
+    this.navigator.snapToSelector?.(selector);
   };
   /**
    * You have attributes in the reader when you initialize it. You can set margin, navigationHeight etc...
    * This is in case you change the attributes after initializing the reader.
    */
   applyAttributes = (value: IFrameAttributes) => {
-    if (this.navigator instanceof IFrameNavigator) {
-      this.navigator.applyAttributes(value);
-    }
+    this.navigator.applyAttributes?.(value);
   };
 
   async applyLineFocusSettings(userSettings) {

--- a/src/utils/EventHandler.ts
+++ b/src/utils/EventHandler.ts
@@ -18,7 +18,7 @@
  */
 
 import { Link } from "../model/Link";
-import { IFrameNavigator } from "../navigator/IFrameNavigator";
+import { EpubNavigator } from "../navigator/EpubNavigator";
 import { Popup } from "../modules/search/Popup";
 import log from "loglevel";
 
@@ -42,9 +42,9 @@ export function removeEventListenerOptional(
 }
 
 export default class EventHandler {
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   popup: Popup;
-  constructor(navigator: IFrameNavigator) {
+  constructor(navigator: EpubNavigator) {
     this.navigator = navigator;
     this.popup = new Popup(this.navigator);
   }

--- a/src/utils/KeyboardEventHandler.ts
+++ b/src/utils/KeyboardEventHandler.ts
@@ -17,12 +17,12 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../navigator/IFrameNavigator";
+import { EpubNavigator } from "../navigator/EpubNavigator";
 
 export default class KeyboardEventHandler {
-  navigator: IFrameNavigator;
+  navigator: EpubNavigator;
   rtl: boolean;
-  constructor(navigator: IFrameNavigator) {
+  constructor(navigator: EpubNavigator) {
     this.navigator = navigator;
     this.rtl = false;
   }

--- a/src/utils/TouchEventHandler.ts
+++ b/src/utils/TouchEventHandler.ts
@@ -17,11 +17,11 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameNavigator } from "../navigator/IFrameNavigator";
+import { EpubNavigator } from "../navigator/EpubNavigator";
 
 export default class TouchEventHandler {
-  navigator: IFrameNavigator;
-  constructor(navigator: IFrameNavigator) {
+  navigator: EpubNavigator;
+  constructor(navigator: EpubNavigator) {
     this.navigator = navigator;
   }
 

--- a/src/views/BookView.ts
+++ b/src/views/BookView.ts
@@ -17,11 +17,11 @@
  * Licensed to: Bokbasen AS and CAST under one or more contributor license agreements.
  */
 
-import { IFrameAttributes } from "../navigator/IFrameNavigator";
+import { IFrameAttributes } from "../navigator/EpubNavigator";
 
 /**
  * Callbacks that the view needs from the navigator.
- * Replaces the old direct IFrameNavigator back-reference.
+ * Replaces the old direct EpubNavigator back-reference.
  */
 export interface BookViewHost {
   checkResourcePosition(): void;

--- a/src/views/BookView.ts
+++ b/src/views/BookView.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 DITA (AM Consulting LLC)
+ * Copyright 2018-2026 DITA (AM Consulting LLC)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,20 @@
  * Licensed to: Bokbasen AS and CAST under one or more contributor license agreements.
  */
 
-import {
-  IFrameNavigator,
-  IFrameAttributes,
-} from "../navigator/IFrameNavigator";
+import { IFrameAttributes } from "../navigator/IFrameNavigator";
+
+/**
+ * Callbacks that the view needs from the navigator.
+ * Replaces the old direct IFrameNavigator back-reference.
+ */
+export interface BookViewHost {
+  checkResourcePosition(): void;
+  recalculateContentProtection(delay?: number): void;
+  isContentProtectionEnabled(): boolean;
+  isFixedLayout(): boolean;
+  isReflowable(): boolean;
+  setDirection(direction?: string | null): void;
+}
 
 interface BookView {
   layout: string;
@@ -30,7 +40,7 @@ interface BookView {
   iframe: Element;
   sideMargin: number;
   height: number;
-  navigator: IFrameNavigator;
+  host: BookViewHost;
   attributes?: IFrameAttributes;
 
   setMode?(scroll: boolean);

--- a/src/views/FixedBookView.ts
+++ b/src/views/FixedBookView.ts
@@ -17,16 +17,13 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import {
-  IFrameNavigator,
-  IFrameAttributes,
-} from "../navigator/IFrameNavigator";
-import BookView from "./BookView";
+import { IFrameAttributes } from "../navigator/IFrameNavigator";
+import BookView, { BookViewHost } from "./BookView";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 
 export default class FixedBookView implements BookView {
   layout = "fixed";
-  navigator: IFrameNavigator;
+  host: BookViewHost;
   name: string;
   label: string;
   iframe: HTMLIFrameElement;

--- a/src/views/FixedBookView.ts
+++ b/src/views/FixedBookView.ts
@@ -17,7 +17,7 @@
  * Licensed to: CAST under one or more contributor license agreements.
  */
 
-import { IFrameAttributes } from "../navigator/IFrameNavigator";
+import { IFrameAttributes } from "../navigator/EpubNavigator";
 import BookView, { BookViewHost } from "./BookView";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -22,7 +22,7 @@ import * as HTMLUtilities from "../utils/HTMLUtilities";
 import * as BrowserUtilities from "../utils/BrowserUtilities";
 import Store from "../store/Store";
 import BookView, { BookViewHost } from "./BookView";
-import { IFrameAttributes } from "../navigator/IFrameNavigator";
+import { IFrameAttributes } from "../navigator/EpubNavigator";
 import debounce from "debounce";
 
 export default class ReflowableBookView implements BookView {

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -21,11 +21,8 @@ import { UserProperty } from "../model/user-settings/UserProperties";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 import * as BrowserUtilities from "../utils/BrowserUtilities";
 import Store from "../store/Store";
-import BookView from "./BookView";
-import {
-  IFrameAttributes,
-  IFrameNavigator,
-} from "../navigator/IFrameNavigator";
+import BookView, { BookViewHost } from "./BookView";
+import { IFrameAttributes } from "../navigator/IFrameNavigator";
 import debounce from "debounce";
 
 export default class ReflowableBookView implements BookView {
@@ -34,7 +31,7 @@ export default class ReflowableBookView implements BookView {
   private readonly USERSETTINGS = "userSetting";
   private readonly store: Store;
   private scrollMode: boolean;
-  navigator: IFrameNavigator;
+  host: BookViewHost;
   constructor(store: Store) {
     this.store = store;
 
@@ -102,8 +99,8 @@ export default class ReflowableBookView implements BookView {
       this.setSize();
       this.padOddColumns();
     }
-    if (this.navigator.rights.enableContentProtection) {
-      this.navigator.contentProtectionModule?.recalculate();
+    if (this.host.isContentProtectionEnabled()) {
+      this.host.recalculateContentProtection();
     }
   }
 
@@ -254,8 +251,8 @@ export default class ReflowableBookView implements BookView {
         element.style.height = originalHeight;
         this.setLeftColumnsWidth(roundedLeftWidth);
 
-        if (this.navigator.rights.enableContentProtection) {
-          this.navigator.contentProtectionModule?.recalculate(0);
+        if (this.host.isContentProtectionEnabled()) {
+          this.host.recalculateContentProtection(0);
         }
       }
     }
@@ -291,8 +288,8 @@ export default class ReflowableBookView implements BookView {
         // Restore element's original height.
         element.style.height = originalHeight;
         this.setLeftColumnsWidth(roundedLeftWidth);
-        if (this.navigator.rights.enableContentProtection) {
-          this.navigator.contentProtectionModule?.recalculate(200);
+        if (this.host.isContentProtectionEnabled()) {
+          this.host.recalculateContentProtection(200);
         }
       }
     }
@@ -361,10 +358,10 @@ export default class ReflowableBookView implements BookView {
       } else {
         this.setLeftColumnsWidth(0);
       }
-      this.navigator.checkResourcePosition();
+      this.host.checkResourcePosition();
     }
-    if (this.navigator.rights.enableContentProtection) {
-      this.navigator.contentProtectionModule?.recalculate();
+    if (this.host.isContentProtectionEnabled()) {
+      this.host.recalculateContentProtection();
     }
   }
 
@@ -394,10 +391,10 @@ export default class ReflowableBookView implements BookView {
       } else {
         this.setLeftColumnsWidth(scrollWidth);
       }
-      this.navigator.checkResourcePosition();
+      this.host.checkResourcePosition();
     }
-    if (this.navigator.rights.enableContentProtection) {
-      this.navigator.contentProtectionModule?.recalculate();
+    if (this.host.isContentProtectionEnabled()) {
+      this.host.recalculateContentProtection();
     }
   }
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -144,6 +144,14 @@
           pub.author = authors.map(a => typeof a === 'string' ? a : a.name || '').filter(Boolean).join(', ');
         }
 
+        // FXL detection
+        const layout = manifest.metadata?.layout
+          || manifest.metadata?.["rendition:layout"]
+          || manifest.metadata?.rendition?.layout;
+        if (layout === "fixed" || layout === "pre-paginated") {
+          pub.fxl = true;
+        }
+
         // Cover image
         const allLinks = [...(manifest.resources || []), ...(manifest.links || [])];
         const cover = allLinks.find(l =>
@@ -195,6 +203,7 @@
             <div class="card-cover" style="${coverStyle}">
               ${pub.coverUrl ? '' : icon}
               <span class="type-badge ${badgeClass}">${pub.type}</span>
+              ${pub.fxl ? '<span class="type-badge" style="background:#e67e22;top:8px;right:auto;left:8px;">FXL</span>' : ''}
               ${pub.hosted ? '<span class="type-badge" style="background:#888;top:8px;right:auto;left:8px;">hosted</span>' : ''}
             </div>
             <div class="card-body">

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -1342,7 +1342,7 @@
             },
             injectables: injectables,
             injectablesFixed: [
-                { type: 'style', url: defined_origin + '/viewer/injectables/style/style.css' },
+                { type: 'style', url: defined_origin + '/viewer/injectables/style/mo.css' },
             ],
             userSettings: userSettings,
             useLocalStorage: true, // true = uses local storage, false = uses session storage (default)

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -569,6 +569,11 @@
 
                                     <li style="display:none"><a class="mui--visible-inline-block  js-show-sidedrawer8"  data-target="container-view-search"  id="menu-button-search"><i class="material-icons">search</i></a></li>
 
+                                    <li style="display:none" id="fxl-zoom-in"><a onclick="d2reader?.zoomIn()"><i class="material-icons">zoom_in</i></a></li>
+                                    <li style="display:none" id="fxl-zoom-out"><a onclick="d2reader?.zoomOut()"><i class="material-icons">zoom_out</i></a></li>
+                                    <li style="display:none" id="fxl-fit-page"><a onclick="d2reader?.fitToPage()"><i class="material-icons">fit_screen</i></a></li>
+                                    <li style="display:none" id="fxl-pan"><a onclick="var on = this.classList.toggle('active'); this.style.color = on ? '#039be5' : ''; on ? d2reader?.activateHand() : d2reader?.deactivateHand()"><i class="material-icons">open_with</i></a></li>
+
                                 </ul>
                             </td>
                         </tr>
@@ -1353,6 +1358,14 @@
         }).then(instance => {
             console.log("D2reader instance ready", instance);
             d2reader = instance;
+
+            // Show FXL zoom buttons if fixed layout
+            if (instance.publicationLayout === "fixed") {
+                document.getElementById("fxl-zoom-in")?.style.removeProperty("display");
+                document.getElementById("fxl-zoom-out")?.style.removeProperty("display");
+                document.getElementById("fxl-fit-page")?.style.removeProperty("display");
+                document.getElementById("fxl-pan")?.style.removeProperty("display");
+            }
 
             // ── Resource lifecycle ──────────────────────────────────
             instance.addEventListener("resource.ready", () => {


### PR DESCRIPTION
## Summary
- **EpubNavigator** — `IFrameNavigator` renamed to `EpubNavigator` (backwards-compat aliases exported)
- **VisualNavigator abstract class** — navigator hierarchy with `NavigatorFeature` capability query system, replaces `instanceof` checks
- **FXL zoom/pan (#899)** — `zoomIn()` / `zoomOut()` / `fitToPage()` with scrollable viewport, GrabToPan hand tool, keyboard shortcuts, pan overlay
- **FXL spread positioning** — checks `properties.page` from manifest, respects `rendition:spread: "none"` for single-page display
- **Spine page-progression-direction** — auto-resolves from manifest metadata for both FXL and reflowable
- **Async navigation** — all navigation methods return `Promise<void>`
- **BookView decoupled** — `BookViewHost` interface replaces direct navigator back-reference
- **MO click-to-jump fix** — re-binds click handler after FXL page turn

Closes #899

See [CHANGES-v3-navigator-refactor.md](docs/v3/CHANGES-v3-navigator-refactor.md) for full details, migration guide, and deferred items.

## Test plan
- [x] FXL zoom in/out/fit-to-page on local viewer (Snow White, Belle)
- [x] FXL pan when zoomed (grab cursor, drag to scroll)
- [x] FXL zoom (API calls: d2reader.zoomIn())
- [x] FXL spread positioning with properties.page (A Bear's Life)
- [x] FXL rendition:spread "none" forces single page (A Bear's Life)
- [x] MO click-to-jump works after FXL page turn
- [x] Reflowable books still work (navigation, settings, MO, TTS)
- [x] PDF books still work (zoom, annotations, search)
- [x] Verify supports() capability queries
- [x] RTL direction: test with RTL book when available (deferred to ReadiumCSS v2 workstream)
