### PR TITLE
v3 workstream 3.5.1: Navigator Config Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/epubs__
 examples/epubs___
 examples/epubs____
 docs/v3/plan
+demo_config*.html

--- a/docs/v3/CHANGES-v3-navigator-config.md
+++ b/docs/v3/CHANGES-v3-navigator-config.md
@@ -1,0 +1,153 @@
+# CHANGES — v3 Workstream 3.5.1: Navigator Config Cleanup
+
+Published as: *pending (will ship as `3.0.0-alpha.18`)*
+Branch: `feature/v3-navigator-config` (stacked on `feature/v3-readiumcss-v2`)
+
+Scoped to `IFrameAttributes`, the iframe-height formula used in reflowable
+paginated mode, and the selection-toolbox placement logic. No other
+navigator or module surface is touched.
+
+## `IFrameAttributes`
+
+Moved from `src/navigator/EpubNavigator.ts` into `src/navigator/types.ts`
+alongside `NavigatorAPI`, `ReaderRights`, and the `Injectable` union.
+`EpubNavigator.ts` re-exports the type for back-compat — integrators
+importing `IFrameAttributes` from the navigator module are unaffected.
+
+### Removed
+
+| Field | Why |
+| --- | --- |
+| `navHeight` | The reader now measures the iframe's outer-viewport offset live via `getBoundingClientRect()` + content-box translation (border + padding). The integrator doesn't need to provide it. |
+| `bottomInfoHeight` | The `#reader-info-bottom` element lives in the integrator's HTML. The integrator owns its CSS height (inline `style="height: Npx;"` or a stylesheet rule). The reader reads the element's rendered height live where it needs it. |
+| `sideNavPosition` | Dead since May 2022 when MUI Sidenav was removed. No code was reading it. |
+
+### Added
+
+**`iframe.padding`** — reflowable iframe CSS padding. Not applied in fixed-layout publications.
+
+```ts
+attributes: {
+  iframe: {
+    padding: 20,                                   // same value on all four sides
+    // or
+    padding: { top: 20, bottom: 20, left: 0, right: 0 },
+  }
+}
+```
+
+Only sides the integrator explicitly specifies are written to the iframe's inline style — unspecified sides inherit from the stylesheet (no forced zero).
+
+**`safeArea`** — integrator-provided callbacks returning the top/bottom chrome elements that the reader should avoid. Used for both selection-toolbox placement **and** iframe height sizing.
+
+```ts
+attributes: {
+  safeArea: {
+    top: () => document.querySelector('.my-navbar'),
+    bottom: () => document.getElementById('my-progress-bar'),
+  }
+}
+```
+
+Each callback is invoked at measure time; the reader measures
+`getBoundingClientRect().height`. Hidden elements (`display: none`,
+`height: 0`) measure as `0`, so toggling chrome visibility reclaims the
+space automatically without any further config changes.
+
+### Changed
+
+- **`margin` is now optional.** Previously required. Default behavior without it: iframe fills its parent container (minus `safeArea.bottom` and iframe padding). Omit it if you don't need extra slack beyond what `safeArea` and iframe padding already reserve.
+
+### Deprecated
+
+- `iframePaddingTop` — kept as fallback when `iframe.padding` is not set. Prefer `iframe.padding.top` (or `iframe.padding` with a number).
+
+## Iframe-height formula
+
+The paginated reflowable iframe-height formula changed from
+`viewport − 40 − margin` to:
+
+```
+iframe.height = parent.clientHeight
+              − safeArea.bottom.height
+              − iframe padding
+              − margin
+```
+
+Extracted into `BrowserUtilities.computeIframeContentHeight(iframe, attributes)`.
+Called from four sites: paginated setup and resize in `EpubNavigator.ts`, and
+paginated height + scroll-mode floor in `ReflowableBookView.ts`.
+
+- The magic `40` offset is gone. It had no semantic meaning — historical
+  residue from a prior hardcoded `100` split into `40 + margin`.
+- The base is the iframe's parent container, not the viewport. Integrators
+  size `#iframe-wrapper` via CSS; the reader reads that live and honors it.
+- Iframe padding is subtracted from the target height so the element's
+  outer rendered size (content-box + padding) matches the space we reserved.
+  Without this, a padded iframe extends past its declared height into
+  adjacent chrome.
+- Hidden `safeArea` elements measure as 0, so toggling chrome visibility
+  (progress bar, translation bar, etc.) resizes the iframe automatically.
+
+**Consequence for integrators:** the `#iframe-wrapper` element must have a
+CSS height. Every integrator's iframe height is different than before —
+reload and verify layout.
+
+## Iframe default display
+
+The reader now sets `iframe.style.verticalAlign = "top"` on every iframe it
+creates or claims (reflowable + FXL second iframe, claim path + create path).
+
+Fixes the ~4–5px baseline-alignment gap below an inline-level iframe that
+would otherwise push `wrapper.scrollHeight` past `clientHeight` and trigger
+the forced `overflow: auto` wrapper scrollbar when the iframe fills its
+parent exactly. Affects every framework example (React, Vue, Next.js,
+Remix, Vanilla, Angular) where the integrator has no `attributes` block.
+
+## Selection toolbox placement
+
+Rewritten to remove the `navHeight` dependency and handle more cases cleanly.
+
+- Translates selection coordinates from iframe-viewport to outer-viewport using the iframe's content-box origin (border-box top + border + padding). Works automatically regardless of iframe chrome.
+- Uses `position: fixed` so `fit-content` width lays icons in one row even inside a narrow parent.
+- Anchors the toolbox at the selection **focus** (where the user released the mouse) instead of the selection's bounding-box center. Direction detection via the Selection API:
+  - Forward selection (top-to-bottom): toolbox below the focus, pointer up.
+  - Backward selection (bottom-to-top): toolbox above the focus, pointer down.
+- Single-line selections always place above (below would overlap the next text line).
+- Adaptive clipping honors `safeArea` and viewport edges — flips to the other side when the preferred side would clip.
+- Horizontal placement centers on the focus X, clamped inside the viewport; if the toolbox is wider than the viewport, it centers.
+- CSS `.below` variant in `_toolbox.scss` flips `transform-origin` and repositions the pointer arrow.
+
+## Fixes
+
+- **Partial `attributes` objects no longer produce `NaN` iframe heights.** `margin` is now optional, and every read site uses `?? 0`. Passing `attributes: {}` or any object missing `margin` returns a concrete number from the formula. The navigator constructor and `applyAttributes()` resolve `this.attributes = attributes ?? {}` — no implicit `{ margin: 0 }` fallback needed.
+
+## Integrator impact
+
+| Change | Impact |
+| --- | --- |
+| `navHeight` removed | Compile error for TypeScript integrators passing it. Runtime: no change — the reader measures live. Remove from config. |
+| `bottomInfoHeight` removed | Compile error for TS integrators passing it. Style the `#reader-info-bottom` element via inline `style` or CSS instead. |
+| `sideNavPosition` removed | Compile error if set. No runtime effect to restore; it was dead. |
+| `iframe.padding` added | Opt-in. Existing integrators unaffected. |
+| `safeArea` added | Opt-in. `safeArea.bottom` now also shortens the iframe so content doesn't sit under fixed bottom chrome. Recommended wherever fixed chrome overlays the iframe area. |
+| `iframePaddingTop` deprecated | Still works via fallback. IDEs show strikethrough; no compile error. Migrate to `iframe.padding.top` when convenient. |
+| `margin` optional | No compile or runtime error for existing integrators. Optional omission enables zero-config layouts when `safeArea` + wrapper CSS cover the space. |
+| Iframe-height formula change | Every integrator's iframe height is different after upgrade. Reload and verify. If `margin` was reserving space for fixed bottom chrome, switch to `safeArea.bottom` and drop the `margin` (they now both subtract if both set). |
+| Iframe `verticalAlign: top` | Purely additive. Eliminates the baseline-gap scrollbar in zero-config integrators. No migration. |
+| NaN fix | Purely additive. Integrators passing `{}` or partial objects and working around the resulting breakage can remove their workarounds. |
+| Toolbox placement | Visible behavioral change. Toolbox now anchors at mouse-up position with direction-aware flip and adaptive clipping. No config needed. |
+
+## Files changed
+
+- `src/navigator/types.ts` — `IFrameAttributes` moved here from EpubNavigator.
+- `src/navigator/EpubNavigator.ts` — re-exports `IFrameAttributes`; constructor + `applyAttributes` simplified to `attributes ?? {}`; iframe padding write logic; iframe `verticalAlign: top` at all claim/create sites; height formula delegated to helper; FXL scroll-container live measurement.
+- `src/utils/BrowserUtilities.ts` — new `computeIframeContentHeight` helper.
+- `src/views/ReflowableBookView.ts` — paginated + scroll-mode floor delegated to helper; default `attributes = {}`.
+- `src/views/FixedBookView.ts` — default `attributes = {}`.
+- `src/modules/highlight/TextHighlighter.ts` — toolbox placement rewrite.
+- `src/styles/sass/reader/_toolbox.scss` — `.below` variant.
+- `viewer/index_dita.html`, `index_dita_v2.html`, `index_dita_v2_cdn.html`, `index_sampleread.html` — `bottomInfoHeight` removed from config, inline height added to `#reader-info-bottom`, `safeArea` example wired in `index_dita.html`.
+- `viewer/index_epub_file.html`, `viewer/index_injectables.html`, `viewer/index_api.html` — `bottomInfoHeight` / `navHeight` removed.
+- `examples/README.md` — updated snippet.
+- `.gitignore` — `demo_config*.html` ignored (local-only config showcase files).

--- a/docs/v3/CHANGES-v3-navigator-config.md
+++ b/docs/v3/CHANGES-v3-navigator-config.md
@@ -1,6 +1,6 @@
 # CHANGES — v3 Workstream 3.5.1: Navigator Config Cleanup
 
-Published as: *pending (will ship as `3.0.0-alpha.18`)*
+Published as: `3.0.0-alpha.18`
 Branch: `feature/v3-navigator-config` (stacked on `feature/v3-readiumcss-v2`)
 
 Scoped to `IFrameAttributes`, the iframe-height formula used in reflowable

--- a/docs/v3/MIGRATION-v3-navigator-config.md
+++ b/docs/v3/MIGRATION-v3-navigator-config.md
@@ -1,0 +1,79 @@
+# Migration — v3 Workstream 3.5.1: Navigator Config Cleanup
+
+## Breaking changes
+
+The following `attributes` fields have been removed. TypeScript users will see compile errors. Remove them from your config:
+
+- `navHeight` — the reader now measures the iframe's outer-viewport offset at runtime.
+- `bottomInfoHeight` — the footer element's height is now owned by the integrator via inline `style` or CSS. The reader reads it live where needed.
+- `sideNavPosition` — no longer referenced by the reader.
+
+## Required
+
+The `#iframe-wrapper` element must have a CSS height. The reader sizes the iframe based on its parent container. Example:
+
+```html
+<main id="iframe-wrapper" style="height: calc(100vh - 65px)"></main>
+```
+
+## Added
+
+**`safeArea`** — integrator-provided callbacks returning the top/bottom chrome elements the reader should avoid. Used for both selection-toolbox placement and iframe sizing.
+
+```js
+attributes: {
+  safeArea: {
+    top: () => document.querySelector('.my-navbar'),
+    bottom: () => document.getElementById('my-footer'),
+  },
+}
+```
+
+Each callback is invoked at measure time; the reader reads `getBoundingClientRect().height`. Hidden elements (`display: none`, `height: 0`) return 0 and the reader reclaims the space automatically — toggling chrome visibility works without any further config.
+
+**`iframe.padding`** — reflowable iframe CSS padding (not applied to fixed-layout publications).
+
+```js
+attributes: {
+  iframe: {
+    padding: 20,                                           // all four sides
+    // or
+    padding: { top: 20, bottom: 0, left: 0, right: 0 },   // per-side
+  },
+}
+```
+
+Only sides explicitly specified are written to the iframe's inline style — unspecified sides inherit from your stylesheet.
+
+## Changed
+
+- **`margin` is now optional.** Previously required. Omit it if you don't need extra space beyond what `safeArea` and iframe padding already reserve.
+
+- **Iframe-height formula.** Was `viewport − 40 − margin`. Now:
+
+  ```
+  iframe.height = wrapper.clientHeight − safeArea.bottom − iframe padding − margin
+  ```
+
+  The magic `40` offset is gone. The resulting iframe height will differ from before — reload and verify your layout.
+
+- **Selection toolbox placement.** Rewritten. The toolbox now:
+  - Anchors at the selection focus (mouse-release point) instead of the selection's bounding-box center.
+  - Flips above/below based on selection direction (forward → below, backward → above).
+  - Always places above for single-line selections.
+  - Honors `safeArea` and viewport edges; flips when the preferred side would clip.
+  - No config needed to get the new behavior.
+
+## Fixed
+
+- Partial `attributes` objects (e.g. `attributes: {}`) no longer produce `NaN` iframe heights.
+
+## Deprecated (continues to work)
+
+- `iframePaddingTop` — prefer `iframe.padding.top`, or `iframe.padding` as a single number for all four sides. The old field still works as a fallback when `iframe.padding` is not set.
+
+## Recommended migration
+
+- If you used `margin` to reserve space for fixed bottom chrome (footer, progress bar), switch to `safeArea.bottom: () => yourFooter` and remove that `margin`.
+- If you have both `margin` and `safeArea.bottom` describing the same chrome, drop one — they are now both subtracted.
+- Move `iframePaddingTop` configs to `iframe.padding.top` when convenient.

--- a/examples/README.md
+++ b/examples/README.md
@@ -111,16 +111,15 @@ D2Reader.load({
     injectables: [...],
     injectablesFixed: [...],
     attributes: {
+        // Extra px reserved below the iframe. Optional.
         margin: 5,
-        // Reflowable iframe CSS padding — single number sets all four sides,
-        // or pass an object { top?, bottom?, left?, right? } for per-side.
-        // Not applied in fixed-layout publications.
+        // Iframe CSS padding. Number sets all four sides, or { top?, bottom?, left?, right? }.
+        // Not applied to fixed-layout publications.
         iframe: {
             padding: { top: 0 },
         },
-        // Live-measured chrome heights the reader avoids when placing the
-        // selection toolbox. Callback returns the element; measured at
-        // placement time so toggling visibility reclaims space automatically.
+        // Fixed chrome the reader avoids for toolbox placement and iframe sizing.
+        // Measured live — toggling visibility reclaims the space automatically.
         safeArea: {
             top: () => document.querySelector('.my-navbar'),
             bottom: () => document.getElementById('my-progress-bar'),

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,9 +112,19 @@ D2Reader.load({
     injectablesFixed: [...],
     attributes: {
         margin: 5,
-        navHeight: 65,
-        iframePaddingTop: 0,
-        bottomInfoHeight: 75,
+        // Reflowable iframe CSS padding — single number sets all four sides,
+        // or pass an object { top?, bottom?, left?, right? } for per-side.
+        // Not applied in fixed-layout publications.
+        iframe: {
+            padding: { top: 0 },
+        },
+        // Live-measured chrome heights the reader avoids when placing the
+        // selection toolbox. Callback returns the element; measured at
+        // placement time so toggling visibility reclaims space automatically.
+        safeArea: {
+            top: () => document.querySelector('.my-navbar'),
+            bottom: () => document.getElementById('my-progress-bar'),
+        },
     },
     rights: {
         enableBookmarks: false,

--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { createRoot } from "react-dom/client";
-import D2Reader from "../../src";
+import D2Reader, { Injectable } from "../../src";
 import readiumBefore from "url:../../viewer/readium-css-v2/ReadiumCSS-before.css";
 import readiumAfter from "url:../../viewer/readium-css-v2/ReadiumCSS-after.css";
 import readiumDefault from "url:../../viewer/readium-css-v2/ReadiumCSS-default.css";
@@ -19,7 +19,7 @@ const isCJK = (pub: any) => {
   );
 };
 
-const injectables = [
+const injectables: Injectable[] = [
   // Base — non-CJK only
   {
     type: "style",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.17",
+  "version": "3.0.0-alpha.18",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/modules/highlight/TextHighlighter.ts
+++ b/src/modules/highlight/TextHighlighter.ts
@@ -1168,14 +1168,120 @@ export class TextHighlighter {
         toolbox.style.position = "absolute";
         toolbox.style.setProperty("--content", "revert");
       } else {
-        const paginated = this.navigator.view?.isPaginated();
-        if (paginated) {
-          toolbox.style.top =
-            rect.top + (this.navigator.attributes?.navHeight ?? 0) + "px";
-        } else {
-          toolbox.style.top = rect.top + "px";
+        // Selection rects are iframe-viewport-relative. Translate to outer-
+        // viewport coords using the iframe's content-box origin (border-box
+        // + border + padding), so the toolbox lines up with the selection
+        // regardless of iframe padding or chrome above.
+        const iframe = this.navigator.iframes[0];
+        const iframeRect = iframe?.getBoundingClientRect();
+        const cs = iframe ? getComputedStyle(iframe) : null;
+        const padTop = cs ? parseFloat(cs.paddingTop) || 0 : 0;
+        const padLeft = cs ? parseFloat(cs.paddingLeft) || 0 : 0;
+        const contentTop =
+          (iframeRect?.top ?? 0) + (iframe?.clientTop ?? 0) + padTop;
+        const contentLeft =
+          (iframeRect?.left ?? 0) + (iframe?.clientLeft ?? 0) + padLeft;
+
+        // Anchor the toolbox at the selection FOCUS (where the user
+        // released the mouse) and flip direction based on whether the
+        // selection went top-to-bottom (focus after anchor → forward) or
+        // bottom-to-top (focus before anchor → backward).
+        const selection = iframe?.contentWindow?.getSelection();
+        let focusRect: DOMRect | null = null;
+        let forward = true;
+        if (selection && selection.focusNode && selection.anchorNode) {
+          const cmp = selection.anchorNode.compareDocumentPosition(
+            selection.focusNode
+          );
+          if (cmp & Node.DOCUMENT_POSITION_PRECEDING) {
+            forward = false; // focus before anchor → backward
+          } else if (cmp === 0) {
+            forward = selection.anchorOffset <= selection.focusOffset;
+          }
+          // Caret rect at the focus position (where mouse-up happened).
+          try {
+            const doc = iframe!.contentDocument!;
+            const focusRange = doc.createRange();
+            focusRange.setStart(selection.focusNode, selection.focusOffset);
+            focusRange.collapse(true);
+            const rects = focusRange.getClientRects();
+            if (rects.length > 0) focusRect = rects[0];
+          } catch (e) {
+            focusRect = null;
+          }
         }
-        toolbox.style.left = (rect.right - rect.left) / 2 + rect.left + "px";
+
+        // Use `position: fixed` so the toolbox is removed from flow (lets
+        // `fit-content` render icons in one row in narrow parents) and
+        // `top` / `left` are viewport-relative — matching the content-box
+        // translation above.
+        toolbox.style.position = "fixed";
+
+        // Default CSS transform: translate(-50%, -100%) — toolbox renders
+        // ABOVE its top anchor (arrow at bottom, pointing down).
+        // `.below` class flips transform-origin and pointer — toolbox
+        // renders BELOW its top anchor (arrow at top, pointing up).
+        const toolboxHeight = toolbox.offsetHeight || 0;
+        const viewportHeight = window.innerHeight;
+
+        // Rects for the top and bottom of the selection in outer-viewport Y.
+        const topEdgeY = (focusRect?.top ?? rect.top) + contentTop;
+        const bottomEdgeY = (focusRect?.bottom ?? rect.bottom) + contentTop;
+
+        // Safe-area reservations from the integrator's `safeArea.top` /
+        // `safeArea.bottom` callbacks — measured live so toggleable chrome
+        // (navbar, progress bar) automatically reclaims space when hidden.
+        const safeArea = this.navigator.attributes?.safeArea;
+        const measure = (cb?: () => Element | null) => {
+          try {
+            return cb?.()?.getBoundingClientRect().height ?? 0;
+          } catch {
+            return 0;
+          }
+        };
+        const safeTop = measure(safeArea?.top);
+        const safeBottom = measure(safeArea?.bottom);
+
+        // Single-line selection → always render toolbox above (below would
+        // overlap the next text line). Multi-line → flip per direction.
+        const selectionRects = range.getClientRects();
+        const multiLine = selectionRects.length > 1;
+        let placeBelow = multiLine && forward;
+        // Adaptive: if the chosen side would clip into the integrator's
+        // safe area (or the viewport edge), flip to the other.
+        const abovewouldClip = topEdgeY - toolboxHeight < safeTop;
+        const belowWouldClip =
+          bottomEdgeY + toolboxHeight > viewportHeight - safeBottom;
+        if (placeBelow && belowWouldClip && !abovewouldClip) {
+          placeBelow = false;
+        } else if (!placeBelow && abovewouldClip && !belowWouldClip) {
+          placeBelow = true;
+        }
+
+        if (placeBelow) {
+          toolbox.classList.add("below");
+          toolbox.style.top = bottomEdgeY + "px";
+        } else {
+          toolbox.classList.remove("below");
+          toolbox.style.top = topEdgeY + "px";
+        }
+
+        // Horizontal: anchor on the focus X (mouse-up X) when available,
+        // else selection's end edge. Clamp inside viewport.
+        const focusX =
+          focusRect != null ? focusRect.left : forward ? rect.right : rect.left;
+        const targetX = contentLeft + focusX;
+        const toolboxWidth = toolbox.offsetWidth || 0;
+        const viewportWidth = window.innerWidth;
+        let clampedX: number;
+        if (toolboxWidth >= viewportWidth) {
+          clampedX = viewportWidth / 2;
+        } else {
+          const minX = toolboxWidth / 2;
+          const maxX = viewportWidth - toolboxWidth / 2;
+          clampedX = Math.max(minX, Math.min(maxX, targetX));
+        }
+        toolbox.style.left = clampedX + "px";
       }
     }
   }
@@ -2384,8 +2490,10 @@ export class TextHighlighter {
           let toolbox = document.getElementById("highlight-toolbox");
 
           if (toolbox) {
-            toolbox.style.top =
-              ev.clientY + (this.navigator.attributes?.navHeight ?? 0) + "px";
+            // ev.clientY is iframe-relative; translate to outer-viewport Y.
+            const iframeTop =
+              this.navigator.iframes[0]?.getBoundingClientRect().top ?? 0;
+            toolbox.style.top = ev.clientY + iframeTop + "px";
             toolbox.style.left = ev.clientX + "px";
 
             if (getComputedStyle(toolbox).display === "none") {
@@ -3296,8 +3404,10 @@ export class TextHighlighter {
         self.lastSelectedHighlight = anno.id;
         let toolbox = document.getElementById("highlight-toolbox");
         if (toolbox) {
-          toolbox.style.top =
-            ev.clientY + (self.navigator.attributes?.navHeight ?? 0) + "px";
+          // ev.clientY is iframe-relative; translate to outer-viewport Y.
+          const iframeTop =
+            self.navigator.iframes[0]?.getBoundingClientRect().top ?? 0;
+          toolbox.style.top = ev.clientY + iframeTop + "px";
           toolbox.style.left = ev.clientX + "px";
 
           if (getComputedStyle(toolbox).display === "none") {

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -716,9 +716,11 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
       let iframe2 = HTMLUtilities.findElement(mainElement, "#second");
 
       if (iframe) {
+        (iframe as HTMLIFrameElement).style.verticalAlign = "top";
         this.iframes.push(iframe);
       }
       if (iframe2) {
+        (iframe2 as HTMLIFrameElement).style.verticalAlign = "top";
         this.iframes.push(iframe2);
       }
       if (window.matchMedia("screen and (max-width: 600px)").matches) {
@@ -738,6 +740,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
         let iframe = document.createElement("iframe");
         iframe.setAttribute("SCROLLING", "no");
         iframe.setAttribute("allowtransparency", "true");
+        iframe.style.verticalAlign = "top";
         this.iframes.push(iframe);
 
         if (this.publication.isFixedLayout) {
@@ -811,6 +814,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
             iframe2.style.opacity = "1";
             iframe2.style.border = "none";
             iframe2.style.overflow = "hidden";
+            iframe2.style.verticalAlign = "top";
             this.iframes.push(iframe2);
 
             secondSpread.appendChild(this.iframes[1]);

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -88,7 +88,12 @@ import type {
   GetContentBytesLength,
   RequestConfig,
 } from "../fetcher/types";
-import type { NavigatorAPI, ReaderRights, Injectable } from "./types";
+import type {
+  NavigatorAPI,
+  ReaderRights,
+  Injectable,
+  IFrameAttributes,
+} from "./types";
 // Re-exported for backwards compatibility.
 export type { GetContent, GetContentBytesLength, RequestConfig };
 export type {
@@ -100,19 +105,8 @@ export type {
   ScriptInjectable,
   InlineStyleInjectable,
   InlineScriptInjectable,
+  IFrameAttributes,
 } from "./types";
-
-export interface IFrameAttributes {
-  margin: number;
-  navHeight?: number;
-  iframePaddingTop?: number;
-  bottomInfoHeight?: number;
-  sideNavPosition?: "left" | "right";
-  /** Margin (in px) around fixed-layout content. Defaults to 100. */
-  fixedLayoutMargin?: number;
-  /** Whether to show a drop shadow on fixed-layout spreads. Defaults to true. */
-  fixedLayoutShadow?: boolean;
-}
 export interface EpubNavigatorConfig {
   mainElement: HTMLElement;
   headerMenu?: HTMLElement | null;
@@ -486,7 +480,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
       config.rights,
       config.tts,
       config.injectables,
-      config.attributes || { margin: 0 },
+      config.attributes,
       config.services,
       config.sample,
       config.requestConfig,
@@ -559,8 +553,9 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
 
     this.settings = settings;
     this.annotator = annotator;
+    this.attributes = attributes ?? {};
     this.view = settings.view;
-    this.view.attributes = attributes;
+    this.view.attributes = this.attributes;
     this.view.host = {
       checkResourcePosition: () => this.checkResourcePosition(),
       recalculateContentProtection: (delay?: number) =>
@@ -594,7 +589,6 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
     };
     this.tts = tts;
     this.injectables = injectables;
-    this.attributes = attributes || { margin: 0 };
     this.services = services;
     this.sample = sample;
     this.requestConfig = requestConfig;
@@ -764,7 +758,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
             timelineEl && this.rights.enableTimeline ? "70px" : "0";
           const infoBottom = document.getElementById("reader-info-bottom");
           this.fxlScrollContainer.style.bottom = infoBottom
-            ? (this.attributes?.bottomInfoHeight ?? 40) + "px"
+            ? infoBottom.offsetHeight + "px"
             : "0";
           this.fxlScrollContainer.style.overflow = "auto";
           this.fxlScrollContainer.style.display = "flex";
@@ -836,8 +830,37 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
             }
           }
         } else {
-          this.iframes[0].style.paddingTop =
-            (this.attributes?.iframePaddingTop ?? 0) + "px";
+          // Reflowable iframe padding — CSS padding applied to the iframe
+          // element itself, shifting its internal browsing context inward
+          // on each side by the given pixel amount. Not applied in FXL.
+          //
+          // New API: `attributes.iframe.padding` accepts a number (all four
+          // sides the same) or a per-side object `{ top, bottom, left, right }`.
+          // Legacy `attributes.iframePaddingTop` still works when the new
+          // API is not set.
+          //
+          // Only sides the integrator explicitly specified are written to
+          // the iframe's inline style. Unspecified sides inherit from the
+          // stylesheet (no forced zero).
+          const iframe = this.iframes[0];
+          const pad = this.attributes?.iframe?.padding;
+          if (pad !== undefined) {
+            if (typeof pad === "number") {
+              iframe.style.padding = pad + "px";
+            } else {
+              if (pad.top !== undefined)
+                iframe.style.paddingTop = pad.top + "px";
+              if (pad.bottom !== undefined)
+                iframe.style.paddingBottom = pad.bottom + "px";
+              if (pad.left !== undefined)
+                iframe.style.paddingLeft = pad.left + "px";
+              if (pad.right !== undefined)
+                iframe.style.paddingRight = pad.right + "px";
+            }
+          } else if (this.attributes?.iframePaddingTop !== undefined) {
+            // Legacy path — iframe.padding not set, honour iframePaddingTop
+            iframe.style.paddingTop = this.attributes.iframePaddingTop + "px";
+          }
         }
       }
 
@@ -1229,8 +1252,10 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
     } else {
       this.settings.isPaginated().then((paginated) => {
         if (paginated) {
-          this.view.height =
-            BrowserUtilities.getHeight() - 40 - (this.attributes?.margin ?? 0);
+          this.view.height = BrowserUtilities.computeIframeContentHeight(
+            this.iframes[0],
+            this.attributes
+          );
           if (this.infoBottom) this.infoBottom.style.removeProperty("display");
           document.body.onscroll = () => {};
           if (this.nextChapterBottomAnchorElement)
@@ -2367,8 +2392,8 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
     }
   }
   applyAttributes(attributes: IFrameAttributes) {
-    this.attributes = attributes;
-    this.view.attributes = attributes;
+    this.attributes = attributes ?? {};
+    this.view.attributes = this.attributes;
     this.handleResize();
   }
 
@@ -2621,18 +2646,17 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
     if (this.infoTop) this.infoTop.style.height = 0 + "px";
     if (this.infoTop) this.infoTop.style.minHeight = 0 + "px";
 
-    // TODO paginator page info
-    // 0 = hide , 40 = show
-    if (this.infoBottom)
-      this.infoBottom.style.height = this.attributes?.bottomInfoHeight
-        ? this.attributes.bottomInfoHeight + "px"
-        : 40 + "px";
+    // #reader-info-bottom height is driven by the integrator's own CSS.
+    // The reader only toggles visibility (display) based on scroll vs
+    // paginated mode — see below.
 
     if (this.view?.layout !== "fixed") {
       this.settings.isPaginated().then((paginated) => {
         if (paginated) {
-          this.view.height =
-            BrowserUtilities.getHeight() - 40 - (this.attributes?.margin ?? 0);
+          this.view.height = BrowserUtilities.computeIframeContentHeight(
+            this.iframes[0],
+            this.attributes
+          );
           if (this.infoBottom) this.infoBottom.style.removeProperty("display");
         } else {
           if (this.infoBottom) this.infoBottom.style.display = "none";

--- a/src/navigator/types.ts
+++ b/src/navigator/types.ts
@@ -168,6 +168,56 @@ export type Injectable =
   | InlineScriptInjectable;
 
 /**
+ * Integrator-supplied configuration for iframe sizing and the selection
+ * toolbox's safe-area avoidance.
+ */
+export interface IFrameAttributes {
+  margin?: number;
+
+  /**
+   * Reflowable iframe styling. Not applied in fixed-layout publications.
+   *
+   * `padding` accepts a single number (same value on all four sides) or an
+   * object with individual `top` / `bottom` / `left` / `right` values.
+   */
+  iframe?: {
+    padding?:
+      | number
+      | {
+          top?: number;
+          bottom?: number;
+          left?: number;
+          right?: number;
+        };
+  };
+
+  /** @deprecated Use `iframe.padding.top`. */
+  iframePaddingTop?: number;
+
+  /**
+   * Integrator-provided "safe areas" at the top and/or bottom of the
+   * viewport that the reader should avoid placing floating UI (selection
+   * toolbox) over. Useful when the integrator renders fixed chrome
+   * (navbar, progress bar, etc.) that overlays the reader.
+   *
+   * Each entry is a callback returning the element whose current height
+   * should be reserved. The reader calls it at placement time and
+   * measures `getBoundingClientRect().height`, so toggling visibility on
+   * the element (e.g. `display: none` → 0 height) automatically reclaims
+   * the space without any further config change.
+   */
+  safeArea?: {
+    top?: () => Element | null;
+    bottom?: () => Element | null;
+  };
+
+  /** Margin (in px) around fixed-layout content. Defaults to 100. */
+  fixedLayoutMargin?: number;
+  /** Whether to show a drop shadow on fixed-layout spreads. Defaults to true. */
+  fixedLayoutShadow?: boolean;
+}
+
+/**
  * Feature toggles gating which modules are loaded and which reader
  * capabilities are exposed. Shared by EpubNavigator and PDFNavigator.
  */

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -1028,8 +1028,9 @@ export default class D2Reader {
     this.navigator.snapToSelector?.(selector);
   };
   /**
-   * You have attributes in the reader when you initialize it. You can set margin, navigationHeight etc...
-   * This is in case you change the attributes after initializing the reader.
+   * Update the navigator `IFrameAttributes` after the reader has been initialized.
+   * Use this to change `margin`, `iframe.padding`, `safeArea`, or fixed-layout
+   * attributes at runtime. The navigator re-applies them on the next resize.
    */
   applyAttributes = (value: IFrameAttributes) => {
     this.navigator.applyAttributes?.(value);

--- a/src/styles/sass/reader/_toolbox.scss
+++ b/src/styles/sass/reader/_toolbox.scss
@@ -39,6 +39,18 @@
     background-color: inherit;
     transform: rotate(45deg);
   }
+  // `.below` — toolbox rendered below the selection end (forward selection).
+  // Transform-origin shifts so the anchor is the toolbox's TOP edge; the
+  // pointer arrow flips to the top, pointing up at the selection.
+  &.below {
+    transform: translate(-50%, 0);
+    transform-origin: top;
+    &:before {
+      $size: 0.4rem;
+      top: - math.div($size, 2);
+      bottom: auto;
+    }
+  }
   > div > button {
     display: inline-block;
   }

--- a/src/utils/BrowserUtilities.ts
+++ b/src/utils/BrowserUtilities.ts
@@ -18,6 +18,7 @@
  */
 
 import * as HTMLUtilities from "./HTMLUtilities";
+import type { IFrameAttributes } from "../navigator/types";
 
 /** Returns the current width of the document. */
 export function getWidth(): number {
@@ -37,6 +38,27 @@ export function getHeight(): number {
   );
 
   return wrapper.clientHeight;
+}
+
+/**
+ * Computes the target height for an iframe rendering reflowable content.
+ *
+ * Formula: `parent.clientHeight − safeArea.bottom − iframe padding − margin`.
+ * Falls back to `getHeight()` if the iframe has no parent.
+ */
+export function computeIframeContentHeight(
+  iframe: HTMLIFrameElement | null | undefined,
+  attributes: IFrameAttributes | undefined
+): number {
+  const parentHeight = iframe?.parentElement?.clientHeight ?? getHeight();
+  const safeAreaBottom =
+    attributes?.safeArea?.bottom?.()?.getBoundingClientRect().height ?? 0;
+  const cs = iframe ? window.getComputedStyle(iframe) : null;
+  const padding =
+    (parseFloat(cs?.paddingTop ?? "0") || 0) +
+    (parseFloat(cs?.paddingBottom ?? "0") || 0);
+  const margin = attributes?.margin ?? 0;
+  return parentHeight - safeAreaBottom - padding - margin;
 }
 
 /** Returns true if the browser is zoomed in with pinch-to-zoom on mobile. */

--- a/src/views/FixedBookView.ts
+++ b/src/views/FixedBookView.ts
@@ -30,7 +30,7 @@ export default class FixedBookView implements BookView {
   iframe2: HTMLIFrameElement;
   sideMargin: number = 20;
   height: number = 0;
-  attributes: IFrameAttributes = { margin: 0 };
+  attributes: IFrameAttributes = {};
 
   start(): void {}
 

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -78,7 +78,10 @@ export default class ReflowableBookView implements BookView {
       this.setSize();
       this.setIframeHeight(this.iframe);
     } else {
-      this.height = BrowserUtilities.getHeight() - 40 - this.attributes.margin;
+      this.height = BrowserUtilities.computeIframeContentHeight(
+        this.iframe,
+        this.attributes
+      );
       this.name = "readium-scroll-off";
       this.label = "Paginated";
       // any is necessary because CSSStyleDeclaration type does not include
@@ -109,7 +112,7 @@ export default class ReflowableBookView implements BookView {
   iframe: HTMLIFrameElement;
   sideMargin: number = 20;
   height: number = 0;
-  attributes: IFrameAttributes = { margin: 0 };
+  attributes: IFrameAttributes = {};
 
   start(): void {
     if (this.scrollMode) {
@@ -498,8 +501,10 @@ export default class ReflowableBookView implements BookView {
           html?.offsetHeight
         );
         if (height) {
-          const minHeight =
-            BrowserUtilities.getHeight() - this.attributes.margin;
+          const minHeight = BrowserUtilities.computeIframeContentHeight(
+            iframe,
+            this.attributes
+          );
           iframe.height = Math.max(minHeight, height) + "px";
         }
       }

--- a/viewer/index_api.html
+++ b/viewer/index_api.html
@@ -695,7 +695,9 @@
         D2Reader.load({
             url: new URL(urlParams['url']),
             attributes: {
+                // Extra px reserved below the iframe. Optional.
                 margin: 15,
+                // @deprecated — use `iframe: { padding: { top: 10 } }`.
                 iframePaddingTop: 10,
             },
             rights: {

--- a/viewer/index_api.html
+++ b/viewer/index_api.html
@@ -459,7 +459,7 @@
                 <div id="lineFocusTopBlinder" class="d2-line-focus-top"></div>
                 <div id="lineFocusBottomBlinder" class="d2-line-focus-bottom"></div>
             </div>
-            <main style="height: calc(100vh - 6px)" tabindex="-1" id="iframe-wrapper">
+            <main style="height: calc(100vh)" tabindex="-1" id="iframe-wrapper">
                 <div id="reader-loading" class="dita-loading"></div>
                 <div id="reader-error" class="dita-error"></div>
                 <div style="height: 0px">

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -593,15 +593,6 @@
                 <div id="reader-info-top" class="dita-info top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="dita-info bottom">
-                    <div style="display: flex;justify-content: center;">
-                        <span class="chapter-position"></span>&nbsp;
-                        <span class="chapter-title"></span>
-                    </div>
-                    <div class="scrubber">
-                        <input class="range-slider__range" style="margin-left:30px;display: none" type="range" min="1" step="1" id="positionSlider" name="positionSlider" onchange="d2reader.goToPosition( this.value )" />
-                    </div>
-                </div>
                 <div style="height: 0px">
                     <div id="highlight-toolbox" class="highlight-toolbox" >
                         <div id="highlight-toolbox-mode-colors">
@@ -659,6 +650,15 @@
                     </div>
                 </div>
             </main>
+            <div id="reader-info-bottom" class="dita-info bottom" style="height: 75px;">
+                <div style="display: flex;justify-content: center;">
+                    <span class="chapter-position"></span>&nbsp;
+                    <span class="chapter-title"></span>
+                </div>
+                <div class="scrubber">
+                    <input class="range-slider__range" style="margin-left:30px;display: none" type="range" min="1" step="1" id="positionSlider" name="positionSlider" onchange="d2reader.goToPosition( this.value )" />
+                </div>
+            </div>
             <div id="container-view-security" class="security"></div>
             <div id="container-view-timeline" class="dita-timeline" style="top: 5rem;bottom: 2.5rem;"></div>
             <a id="previous-chapter" rel="prev" role="button" aria-labelledby="previous-label"
@@ -973,11 +973,25 @@
             //     mode: "cors",
             //     credentials: "include",
             // },
-            attributes: { // TODO: review these attributes and eventually needs better naming.
-                margin: 75, // subtract this from the iframe height , when setting the iframe minimum height
-                navHeight: 10, // used for positioning the toolbox
-                iframePaddingTop: 20, // top padding inside iframe
-                bottomInfoHeight: 75, // #reader-info-bottom height
+            attributes: {
+                // margin: 65, // subtract this from the iframe height , when setting the iframe minimum height
+                // iframePaddingTop: 20, // top padding inside iframe
+                iframe: {
+                  padding: {
+                    bottom: 20
+                  }
+                },
+                // Reserve live-measured space for the integrator's top + bottom chrome
+                // so the selection toolbox never overlaps them. Toggling visibility on
+                // these elements automatically reclaims the space.
+                safeArea: {
+                    top: () => document.querySelector('.mui-appbar'),
+                    bottom: () => document.getElementById('reader-info-bottom'),
+                },
+                // `margin` not set — reader fills the iframe's parent container
+                // (`#iframe-wrapper`), whose CSS height (`calc(100vh - 140px)`)
+                // accounts for the 65px top bar and the 75px #reader-info-bottom
+                // strip below it.
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -974,16 +974,16 @@
             //     credentials: "include",
             // },
             attributes: {
-                // margin: 65, // subtract this from the iframe height , when setting the iframe minimum height
-                // iframePaddingTop: 20, // top padding inside iframe
+                // margin: 65,            // Extra px reserved below the iframe. Optional.
+                // iframePaddingTop: 20,  // @deprecated — use `iframe.padding.top`.
+                // Iframe CSS padding. Not applied to fixed-layout.
                 iframe: {
                   padding: {
                     bottom: 20
                   }
                 },
-                // Reserve live-measured space for the integrator's top + bottom chrome
-                // so the selection toolbox never overlaps them. Toggling visibility on
-                // these elements automatically reclaims the space.
+                // Fixed chrome the reader avoids for toolbox placement and iframe sizing.
+                // Measured live — toggling visibility reclaims the space automatically.
                 safeArea: {
                     top: () => document.querySelector('.mui-appbar'),
                     bottom: () => document.getElementById('reader-info-bottom'),

--- a/viewer/index_dita_v2.html
+++ b/viewer/index_dita_v2.html
@@ -1088,9 +1088,11 @@
             //     mode: "cors",
             //     credentials: "include",
             // },
-            attributes: { // TODO: review these attributes and eventually needs better naming.
-                margin: 75, // subtract this from the iframe height , when setting the iframe minimum height
-                iframePaddingTop: 20, // top padding inside iframe
+            attributes: {
+                // Extra px reserved below the iframe. Optional.
+                margin: 75,
+                // @deprecated — use `iframe: { padding: { top: 20 } }`.
+                iframePaddingTop: 20,
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_dita_v2.html
+++ b/viewer/index_dita_v2.html
@@ -687,7 +687,7 @@
                 <div id="reader-info-top" class="dita-info top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="dita-info bottom">
+                <div id="reader-info-bottom" class="dita-info bottom" style="height: 75px;">
                     <div style="display: flex;justify-content: center;">
                         <span class="chapter-position"></span>&nbsp;
                         <span class="chapter-title"></span>
@@ -1090,9 +1090,7 @@
             // },
             attributes: { // TODO: review these attributes and eventually needs better naming.
                 margin: 75, // subtract this from the iframe height , when setting the iframe minimum height
-                navHeight: 10, // used for positioning the toolbox
                 iframePaddingTop: 20, // top padding inside iframe
-                bottomInfoHeight: 75, // #reader-info-bottom height
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_dita_v2_cdn.html
+++ b/viewer/index_dita_v2_cdn.html
@@ -1074,9 +1074,11 @@
             //     mode: "cors",
             //     credentials: "include",
             // },
-            attributes: { // TODO: review these attributes and eventually needs better naming.
-                margin: 75, // subtract this from the iframe height , when setting the iframe minimum height
-                iframePaddingTop: 20, // top padding inside iframe
+            attributes: {
+                // Extra px reserved below the iframe. Optional.
+                margin: 75,
+                // @deprecated — use `iframe: { padding: { top: 20 } }`.
+                iframePaddingTop: 20,
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_dita_v2_cdn.html
+++ b/viewer/index_dita_v2_cdn.html
@@ -687,7 +687,7 @@
                 <div id="reader-info-top" class="dita-info top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="dita-info bottom">
+                <div id="reader-info-bottom" class="dita-info bottom" style="height: 75px;">
                     <div style="display: flex;justify-content: center;">
                         <span class="chapter-position"></span>&nbsp;
                         <span class="chapter-title"></span>
@@ -1076,9 +1076,7 @@
             // },
             attributes: { // TODO: review these attributes and eventually needs better naming.
                 margin: 75, // subtract this from the iframe height , when setting the iframe minimum height
-                navHeight: 10, // used for positioning the toolbox
                 iframePaddingTop: 20, // top padding inside iframe
-                bottomInfoHeight: 75, // #reader-info-bottom height
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_epub_file.html
+++ b/viewer/index_epub_file.html
@@ -233,7 +233,6 @@
                     useLocalStorage: true,
                     attributes: {
                         margin: 51,
-                        navHeight: 10,
                     },
                     rights: {
                         enableBookmarks: true,
@@ -276,9 +275,7 @@
                     useLocalStorage: true,
                     attributes: {
                         margin: 51,
-                        navHeight: 10,
                         iframePaddingTop: 20,
-                        bottomInfoHeight: 0,
                     },
                     rights: {
                         enableBookmarks: true,

--- a/viewer/index_epub_file.html
+++ b/viewer/index_epub_file.html
@@ -232,6 +232,7 @@
                     injectablesFixed: [],
                     useLocalStorage: true,
                     attributes: {
+                        // Extra px reserved below the iframe. Optional.
                         margin: 51,
                     },
                     rights: {
@@ -274,7 +275,9 @@
                     injectablesFixed: [],
                     useLocalStorage: true,
                     attributes: {
+                        // Extra px reserved below the iframe. Optional.
                         margin: 51,
+                        // @deprecated — use `iframe: { padding: { top: 20 } }`.
                         iframePaddingTop: 20,
                     },
                     rights: {

--- a/viewer/index_injectables.html
+++ b/viewer/index_injectables.html
@@ -376,6 +376,11 @@
             url: new URL(urlParams['url']),
             injectables: injectables,
             injectablesFixed: [],
+            attributes: {
+              margin: -40,
+              // navHeight: 76,
+              iframePaddingTop: 20,
+            },
             api: {
                 updateCurrentLocation: async function (loc) {
                     const title = loc.title || '';

--- a/viewer/index_injectables.html
+++ b/viewer/index_injectables.html
@@ -377,8 +377,9 @@
             injectables: injectables,
             injectablesFixed: [],
             attributes: {
+              // Extra px reserved below the iframe. Optional.
               margin: -40,
-              // navHeight: 76,
+              // @deprecated — use `iframe: { padding: { top: 20 } }`.
               iframePaddingTop: 20,
             },
             api: {

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -458,10 +458,11 @@
         D2Reader.load({
             url: new URL(urlParams['url']),
             attributes: {
+                // Extra px reserved below the iframe. Optional.
                 margin: 40,
-                // iframePaddingTop: 20,
-                iframe:{
-                  padding:{
+                // Iframe CSS padding. Not applied to fixed-layout.
+                iframe: {
+                  padding: {
                     top: 20
                   }
                 }

--- a/viewer/index_sampleread.html
+++ b/viewer/index_sampleread.html
@@ -318,7 +318,7 @@
                 <div id="reader-info-top" class="dita-info top">
                     <span class="book-title"></span>
                 </div>
-                <div id="reader-info-bottom" class="dita-info bottom">
+                <div id="reader-info-bottom" class="dita-info bottom" style="height: 60px;">
                     <div style="display: flex;justify-content: center;">
                         <span class="chapter-position"></span>&nbsp;
                         <span class="chapter-title"></span>
@@ -458,11 +458,13 @@
         D2Reader.load({
             url: new URL(urlParams['url']),
             attributes: {
-                margin: 120,
-                navHeight: 76,
-                iframePaddingTop: 20,
-                bottomInfoHeight: 60,
-                sideNavPosition: 'right'
+                margin: 40,
+                // iframePaddingTop: 20,
+                iframe:{
+                  padding:{
+                    top: 20
+                  }
+                }
             },
             rights: {
                 enableMaterial: true,


### PR DESCRIPTION
Audits, cleans up, and extends the navigator attributes surface exposed on `D2Reader.load({ attributes })`. Fixes the hardcoded `-40` coupling bug and the baseline-gap scrollbar in zero-config integrators.

## Changes

**`IFrameAttributes`**
- Moved into `src/navigator/types.ts`; `EpubNavigator.ts` re-exports for back-compat.
- Removed: `navHeight`, `bottomInfoHeight`, `sideNavPosition`.
- Added: `iframe.padding` (number or per-side), `safeArea.top`/`safeArea.bottom` callbacks.
- `margin` is now optional; `iframePaddingTop` deprecated (kept as fallback).

**Iframe-height formula**
- Replaces `viewport − 40 − margin` with `parent.clientHeight − safeArea.bottom − iframe padding − margin`.
- Extracted into `BrowserUtilities.computeIframeContentHeight(iframe, attributes)`.
- Four call sites delegate through the helper.
- `safeArea.bottom` is measured live — hiding chrome reclaims the space automatically.

**Baseline-gap fix**
- `iframe.style.verticalAlign = "top"` set on every iframe the reader creates or claims.
- Eliminates the ~4–5px scrollbar on zero-config integrators (React/Vue/Next.js/Remix/Vanilla/Angular).

**Selection toolbox placement**
- Rewritten to anchor at selection focus with direction-aware flip, adaptive clipping honoring `safeArea`, and `position: fixed` for single-row icon layout.
- Removes the `navHeight` dependency.

## Commits

1. `cba8984` refactor(highlight): rewrite selection-toolbox placement
2. `77aeed9` refactor(navigator): iframe attributes cleanup + height formula
3. `ff9088f` fix(navigator): eliminate iframe baseline-gap scrollbar
4. `e232e13` chore(demos): update viewer demos for navigator attributes cleanup
5. `9f629bd` docs: v3 navigator-config CHANGES + MIGRATION

## Docs

- `docs/v3/CHANGES-v3-navigator-config.md` — internal notes + integrator impact table.
- `docs/v3/MIGRATION-v3-navigator-config.md` — integrator-facing migration guide.

## Integrator impact

- Compile errors for TS integrators passing removed fields — delete from config.
- `#iframe-wrapper` must have a CSS height (most integrators already do).
- Every integrator's iframe height will differ from before — reload and verify.
- Integrators using `margin` to reserve space for fixed bottom chrome should switch to `safeArea.bottom: () => yourFooter`.

## Test plan

- [x] DITA viewer demos — layout renders correctly, selection toolbox anchors and flips as expected.
- [x] Framework examples (React, Vue, Next.js, Remix, Vanilla, Angular) — no wrapper scrollbar with zero config.
- [x] FXL publications — unchanged behavior.
- [x] Scroll mode — min-height floor uses new formula.
- [x] Pre-existing integrators with `margin: N` (no `safeArea`) — continues to work.