### PR TITLE
fix(navigator): restore scroll on chapter navigation when progression is 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.18",
+  "version": "3.0.0-alpha.19",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -1822,7 +1822,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
           if (startContainer) {
             this.view?.goToCssSelector(startContainer);
           }
-        } else if (bookViewPosition && bookViewPosition >= 0) {
+        } else if (bookViewPosition !== undefined && bookViewPosition >= 0) {
           // Inject the odd-column spacer before restoring progression so the
           // progression-to-scroll math uses the final, even-column layout.
           // Without this, refreshing on an odd-column page restores position


### PR DESCRIPTION
## Bug

Chapter navigation (next chapter button, TOC click on a chapter start) and any locator with `progression: 0` left the iframe at the previous chapter's scroll position. User clicked next chapter and landed mid-content of the new chapter at whatever offset the previous chapter's scroll happened to be.

## Root cause

In `handleIFrameLoad` the position-restore branch is gated by:

```ts
} else if (bookViewPosition && bookViewPosition >= 0) {
  ...
  this.view?.goToProgression(bookViewPosition);
}
```

`bookViewPosition && ...` is falsy when `bookViewPosition === 0`, so `goToProgression(0)` is skipped.

Pre-3.4 this was harmless: chapter content was loaded via `iframe.src = href`, which triggers native browser navigation and resets the iframe's scroll position to 0. After workstream 3.4 (`feature/v3-fetcher`, PR #1158) all content flows through the Fetcher pipeline and is written via `document.write`, which does **not** reset scroll. The iframe kept the previous chapter's `scrollTop` / `scrollLeft` and the user landed at an arbitrary position.

## Fix

Honour `progression === 0` by checking for `undefined` explicitly:

```diff
- } else if (bookViewPosition && bookViewPosition >= 0) {
+ } else if (bookViewPosition !== undefined && bookViewPosition >= 0) {
```

`goToProgression(0)` now actually fires and resets scroll.

## Affected

Every reader since alpha.15 (workstream 3.4) shipping under `v3` — alpha.15, alpha.16, alpha.17, alpha.18.

## Test plan

- [x] Click next-chapter button — lands at top of new chapter (not mid-chapter at stale offset).
- [x] Click previous-chapter button — still lands at end of prev chapter (unchanged; `progression: 1` was always honoured).
- [x] Click any TOC entry that points at a chapter start — lands at top.
- [x] Click a TOC entry with a fragment / mid-chapter progression — lands at the fragment / progression as before.
- [x] Reload at a saved progression mid-chapter — restores correctly (unchanged path).

## Ships as

`3.0.0-alpha.19`