### PR TITLE
v3 workstream 3.5.2: Scroll Container Option

### DIFF
--- a/docs/v3/CHANGES-v3-scroll-container.md
+++ b/docs/v3/CHANGES-v3-scroll-container.md
@@ -1,0 +1,89 @@
+# CHANGES — v3 Workstream 3.5.2: Scroll Container Option
+
+Published as: *pending (will ship as `3.0.0-alpha.20`)*
+Branch: `feature/v3-scroll-container` (stacked on `v3`, which now includes the chapter-nav scroll-reset bugfix shipped as `3.0.0-alpha.19`)
+
+Adds opt-in alternate viewport model for scroll mode. Default behaviour unchanged.
+
+## What changed
+
+### `IFrameAttributes.scrollContainer`
+
+New optional field on `IFrameAttributes` controls which element provides the scrollbar in scroll mode:
+
+```ts
+attributes: {
+  scrollContainer: "host" | "iframe",   // default "host"
+}
+```
+
+- **`"host"` (default):** `#iframe-wrapper` scrolls. Iframe grows to its content's full height. Existing v2.x behaviour.
+- **`"iframe"`:** iframe stays at viewport height (`wrapper.clientHeight − safeArea.bottom − iframe padding − margin`). The iframe's own document scrolls internally.
+
+Only affects scroll mode. Paginated and fixed-layout are unchanged.
+
+### Why `"iframe"` mode exists
+
+Integrators who inject styles like `body { height: 100% }` (commonly seen on cover pages) trigger a 100%-height-chain in host mode: `iframe.height` is computed from content `scrollHeight`, but content height equals iframe height (because `body` is 100% of iframe), so each paint grows the iframe. Iframe-scroll mode breaks the loop because the iframe is fixed-size and its document overflows internally.
+
+## Implementation
+
+### `src/navigator/types.ts`
+
+`scrollContainer?: "host" | "iframe"` added to `IFrameAttributes`.
+
+### `src/views/ReflowableBookView.ts`
+
+New private helpers route every scroll-mode read/write through one of two scroll containers:
+
+- `scrollContainerMode` — getter, returns `"host"` or `"iframe"`.
+- `getScrollOffset()` — reads `wrapper.scrollTop` (host) or `scrollingElement.scrollTop` (iframe).
+- `setScrollOffset(n)` — writes the appropriate target.
+- `getScrollExtent()` — `scrollingElement.scrollHeight` (same in both modes — iframe's internal document is the source of truth for content height).
+
+Six scroll-mode call sites refactored to use the helpers:
+
+- `getCurrentPosition()`
+- `goToProgression()`
+- `atStart()` / `atEnd()`
+- `goToPreviousPage()` / `goToNextPage()`
+
+Iframe sizing branched in `setSize()`:
+
+- Paginated: iframe + `documentElement` constrained to `this.height`.
+- Iframe-scroll: iframe at `this.height`; `documentElement` left unconstrained (so it overflows and scrolls).
+- Host-scroll: iframe grows to `html.offsetHeight`.
+
+`setIframeHeight()` (the debounced grow-to-content path) skips entirely in iframe-scroll mode.
+
+`setMode(scroll)` computes `this.height = computeIframeContentHeight(...)` when entering scroll mode in iframe-scroll configuration, so `setSize()` has a target height to apply.
+
+### `src/navigator/EpubNavigator.ts`
+
+The scroll handler in `updateBookView()` is extracted into a single `onScroll` const, then attached to either `wrapper.onscroll` (host) or `iframe.contentWindow.onscroll` (iframe). Re-attached on every `updateBookView` call so chapter swaps (new `contentWindow`) get a fresh listener.
+
+When iframe mode is active the wrapper handler is explicitly cleared (`wrapper.onscroll = null`) to avoid lingering reference if a previous load was in host mode.
+
+### Module-level scroll reads (unchanged)
+
+`TextHighlighter`, `Popup`, `LineFocusModule`, `ContentProtectionModule`, `TTSModule2` already read `iframe.contentDocument.scrollingElement.scrollTop`. In host mode that's always 0 (iframe doesn't scroll internally) so those reads behave as iframe-local positioning. In iframe mode they start returning meaningful values automatically. No code changes; behaviour becomes more consistent with what those modules were already written to assume.
+
+## Not in this release
+
+- **`ResizeObserver` alternate target** — there's no `ResizeObserver` in the codebase today, so no alternate to wire.
+- **Explicit chapter-swap scroll reset** — `document.write` already resets the iframe's internal scroll to 0 on each chapter load.
+
+## Integrator impact
+
+| Change | Impact |
+| --- | --- |
+| `scrollContainer` added | Opt-in. Default `"host"` preserves existing behaviour byte-for-byte. |
+| Iframe-scroll mode | Recommended when integrators inject styles that create a 100%-height chain on the iframe body, or whenever a fixed-viewport iframe makes more sense than a host-scrolling layout. |
+| Locator portability | Position math computes the same ratio in both modes — saved positions transfer cleanly when an integrator switches modes. |
+| Selection / annotations / TTS | Module code reading `iframe.contentDocument.scrollingElement.scrollTop` becomes more accurate in iframe mode (the iframe actually scrolls). No config change required. |
+
+## Files changed
+
+- `src/navigator/types.ts` — `scrollContainer` field added to `IFrameAttributes`.
+- `src/views/ReflowableBookView.ts` — helpers + branched scroll-mode paths + iframe sizing branch + scroll-mode start setup.
+- `src/navigator/EpubNavigator.ts` — scroll event source branch (`wrapper` vs `iframe.contentWindow`).

--- a/docs/v3/CHANGES-v3-scroll-container.md
+++ b/docs/v3/CHANGES-v3-scroll-container.md
@@ -1,6 +1,6 @@
 # CHANGES — v3 Workstream 3.5.2: Scroll Container Option
 
-Published as: *pending (will ship as `3.0.0-alpha.20`)*
+Published as: `3.0.0-alpha.20`
 Branch: `feature/v3-scroll-container` (stacked on `v3`, which now includes the chapter-nav scroll-reset bugfix shipped as `3.0.0-alpha.19`)
 
 Adds opt-in alternate viewport model for scroll mode. Default behaviour unchanged.

--- a/docs/v3/MIGRATION-v3-scroll-container.md
+++ b/docs/v3/MIGRATION-v3-scroll-container.md
@@ -1,0 +1,85 @@
+# Migration — v3 Workstream 3.5.2: Scroll Container Option
+
+Opt-in. No action required for existing integrators.
+
+## What's new
+
+A new field on `IFrameAttributes` lets you pick which element scrolls in scroll mode:
+
+```ts
+attributes: {
+  scrollContainer: "host" | "iframe",   // default "host"
+}
+```
+
+- **`"host"` (default):** `#iframe-wrapper` scrolls; iframe grows to fit its content. Same behaviour you've always had.
+- **`"iframe"`:** iframe stays at viewport height; iframe's own document scrolls internally.
+
+Only affects scroll mode. Paginated and fixed-layout are unchanged regardless of the value.
+
+## When to use `"iframe"`
+
+Use `"iframe"` mode when your integrator-supplied injectables style the iframe body to fill the viewport (for example `body { height: 100% }` on cover pages). In default `"host"` mode, that styling combined with iframe-grows-to-content produces a feedback loop where the iframe's height grows on every paint. `"iframe"` mode prevents the loop because the iframe is fixed-size; the body overflows and scrolls inside it.
+
+If you don't inject those kinds of body styles and your integration works today, leave `scrollContainer` unset.
+
+## Behaviour notes
+
+- **Position is portable across modes.** Saved bookmarks and reading positions computed in one mode restore correctly in the other. The progression ratio (`scrollOffset / scrollExtent`) is identical regardless of which element provides the scrollbar.
+- **Selection, annotations, line focus, TTS overlays:** these read the iframe's internal scroll position, which is more accurate in `"iframe"` mode. No configuration change needed.
+- **Scrollbar position changes.** In `"host"` mode the scrollbar lives on `#iframe-wrapper`; in `"iframe"` mode it lives inside the iframe. Style accordingly if your CSS targets a specific scrollbar location.
+
+## Things to check before enabling
+
+### Custom scrollbar CSS
+
+Any rule you have like:
+
+```css
+#iframe-wrapper::-webkit-scrollbar { ... }
+#iframe-wrapper { scrollbar-width: thin; }
+```
+
+stops applying to chapter scroll in `"iframe"` mode — the wrapper no longer scrolls. To style the in-iframe scrollbar, inject the rule into the iframe via the reader's `injectables`:
+
+```ts
+injectables: [
+  { type: "style-inline", source: `html::-webkit-scrollbar { width: 6px }` },
+]
+```
+
+### Programmatic scroll from outside the reader
+
+Any external code that scrolls the wrapper directly:
+
+```js
+document.querySelector("#iframe-wrapper").scrollTo({ top: 0 });
+```
+
+won't move chapter content in `"iframe"` mode. Use the reader API instead — `reader.goToProgression(0)` or other navigation methods work in both modes.
+
+### Cross-origin chapter content
+
+`"iframe"` mode attaches a scroll listener on `iframe.contentWindow`. If chapter content is served from a different origin than the host page, browser cross-origin policy blocks that listener and scroll-driven features (position save, atStart/atEnd UI, anchor visibility) won't fire. R2D2BC's standard webpub setup serves chapters same-origin via the fetcher, so this only matters if you've configured a non-standard cross-origin source.
+
+### Switching modes at runtime
+
+`scrollContainer` is part of `IFrameAttributes`, so you can switch at runtime via `reader.applyAttributes({ scrollContainer: "iframe" })`. The reader re-applies sizing on the next resize. Save the user's position before switching and restore it after, in case any layout reflow nudges the offset.
+
+### Touch / keyboard navigation
+
+Swipe and arrow-key navigation work the same in both modes — they go through the navigator's own page-turn API, not directly through the scroll container.
+
+## Example
+
+```ts
+D2Reader.load({
+  url: new URL(manifest),
+  attributes: {
+    scrollContainer: "iframe",
+  },
+  // ...rest of config
+});
+```
+
+That's it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "3.0.0-alpha.19",
+  "version": "3.0.0-alpha.20",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -1826,6 +1826,16 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
       }
 
       setTimeout(async () => {
+        // Wait for the iframe's @font-face fonts to load before restoring
+        // position. Font loading is asynchronous and reflows the document
+        // when it completes — without this, scrollHeight (scroll mode) and
+        // column widths (paginated) computed before fonts arrive are stale,
+        // and the saved progression maps to the wrong px/column. Resolves
+        // immediately when no fonts are pending.
+        const iframeDocument = iframe.contentDocument as any;
+        if (iframeDocument?.fonts?.ready) {
+          await iframeDocument.fonts.ready;
+        }
         if (this.newElementId) {
           const element = (iframe.contentDocument as any).getElementById(
             this.newElementId

--- a/src/navigator/EpubNavigator.ts
+++ b/src/navigator/EpubNavigator.ts
@@ -738,7 +738,14 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
       if (this.iframes.length === 0) {
         wrapper.style.overflow = "auto";
         let iframe = document.createElement("iframe");
-        iframe.setAttribute("SCROLLING", "no");
+        // `scrolling="no"` disables the iframe's internal scrollbar — required
+        // in host-scroll mode (iframe grows to content; #iframe-wrapper scrolls).
+        // In iframe-scroll mode the iframe stays at viewport size and its own
+        // document needs to scroll, so we use `auto`.
+        iframe.setAttribute(
+          "scrolling",
+          this.attributes?.scrollContainer === "iframe" ? "auto" : "no"
+        );
         iframe.setAttribute("allowtransparency", "true");
         iframe.style.verticalAlign = "top";
         this.iframes.push(iframe);
@@ -1338,8 +1345,7 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
             "#iframe-wrapper"
           );
 
-          // document.body.style.overflow = "auto";
-          wrapper.onscroll = async () => {
+          const onScroll = async () => {
             this.isScrolling = true;
             await this.savePosition();
             if (this.view?.atEnd()) {
@@ -1392,6 +1398,19 @@ export class EpubNavigator extends VisualNavigator implements EpubModuleHost {
             }
             onDoScrolling();
           };
+
+          // Scroll event source depends on `attributes.scrollContainer`:
+          // - "host" (default): #iframe-wrapper scrolls (iframe grows to content).
+          // - "iframe": iframe's own contentWindow scrolls (iframe stays at viewport).
+          // Re-attached on every updateBookView so a chapter swap (new
+          // contentWindow) gets a fresh listener.
+          if (this.attributes?.scrollContainer === "iframe") {
+            wrapper.onscroll = null;
+            const cw = this.iframes[0]?.contentWindow;
+            if (cw) cw.onscroll = onScroll;
+          } else {
+            wrapper.onscroll = onScroll;
+          }
 
           if (this.chapterTitle) this.chapterTitle.style.display = "none";
           if (this.chapterPosition) this.chapterPosition.style.display = "none";

--- a/src/navigator/types.ts
+++ b/src/navigator/types.ts
@@ -211,6 +211,19 @@ export interface IFrameAttributes {
     bottom?: () => Element | null;
   };
 
+  /**
+   * Scroll-mode viewport model. Opt-in.
+   *
+   * - `"host"` (default): iframe grows to its content height and
+   *   `#iframe-wrapper` provides the scrollbar. Existing behaviour.
+   * - `"iframe"`: iframe stays at viewport height and scrolls internally.
+   *   Prevents the feedback loop when injected styles create a 100%
+   *   height chain (e.g. `body { height: 100% }` on cover pages).
+   *
+   * Only affects scroll mode. Paginated and fixed-layout are unchanged.
+   */
+  scrollContainer?: "host" | "iframe";
+
   /** Margin (in px) around fixed-layout content. Defaults to 100. */
   fixedLayoutMargin?: number;
   /** Whether to show a drop shadow on fixed-layout spreads. Defaults to true. */

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -75,6 +75,15 @@ export default class ReflowableBookView implements BookView {
         const spacer = doc.getElementById("r2d2bc-column-spacer");
         if (spacer) spacer.remove();
       }
+      // In iframe-scroll mode, the iframe stays at viewport height and its
+      // own document scrolls. Compute the target height the same way the
+      // paginated path does so the iframe fits the wrapper minus chrome.
+      if (this.scrollContainerMode === "iframe") {
+        this.height = BrowserUtilities.computeIframeContentHeight(
+          this.iframe,
+          this.attributes
+        );
+      }
       this.setSize();
       this.setIframeHeight(this.iframe);
     } else {
@@ -168,13 +177,9 @@ export default class ReflowableBookView implements BookView {
   }
 
   getCurrentPosition(): number {
-    const wrapper = HTMLUtilities.findRequiredElement(
-      document,
-      "#iframe-wrapper"
-    );
-
     if (this.scrollMode) {
-      return wrapper.scrollTop / this.scrollingElement.scrollHeight;
+      const extent = this.getScrollExtent();
+      return extent > 0 ? this.getScrollOffset() / extent : 0;
     } else {
       const width = this.getColumnWidth();
       const leftWidth = this.getLeftColumnsWidth();
@@ -185,33 +190,29 @@ export default class ReflowableBookView implements BookView {
   }
 
   goToProgression(position: number): void {
-    const wrapper = HTMLUtilities.findRequiredElement(
-      document,
-      "#iframe-wrapper"
-    );
     if (this.scrollMode) {
-      wrapper.scrollTop = this.scrollingElement.scrollHeight * position;
-    } else {
-      // If the window has changed size since the columns were set up,
-      // we need to reset position, so we can determine the new total width.
-
-      const width = this.getColumnWidth();
-      const leftWidth = this.getLeftColumnsWidth();
-      const rightWidth = this.getRightColumnsWidth();
-      const totalWidth = leftWidth + width + rightWidth;
-
-      const newLeftWidth = position * totalWidth;
-
-      // Round the new left width, so it's a multiple of the column width.
-
-      let roundedLeftWidth = Math.round(newLeftWidth / width) * width;
-      if (roundedLeftWidth >= totalWidth) {
-        // We've gone too far and all the columns are off to the left.
-        // Move one column back into the viewport.
-        roundedLeftWidth = roundedLeftWidth - width;
-      }
-      this.setLeftColumnsWidth(roundedLeftWidth);
+      this.setScrollOffset(this.getScrollExtent() * position);
+      return;
     }
+    // If the window has changed size since the columns were set up,
+    // we need to reset position, so we can determine the new total width.
+
+    const width = this.getColumnWidth();
+    const leftWidth = this.getLeftColumnsWidth();
+    const rightWidth = this.getRightColumnsWidth();
+    const totalWidth = leftWidth + width + rightWidth;
+
+    const newLeftWidth = position * totalWidth;
+
+    // Round the new left width, so it's a multiple of the column width.
+
+    let roundedLeftWidth = Math.round(newLeftWidth / width) * width;
+    if (roundedLeftWidth >= totalWidth) {
+      // We've gone too far and all the columns are off to the left.
+      // Move one column back into the viewport.
+      roundedLeftWidth = roundedLeftWidth - width;
+    }
+    this.setLeftColumnsWidth(roundedLeftWidth);
   }
 
   goToCssSelector(cssSelector: string, relative?: boolean): void {
@@ -301,12 +302,7 @@ export default class ReflowableBookView implements BookView {
   // at top in scroll mode
   atStart(): boolean {
     if (this.scrollMode) {
-      const wrapper = HTMLUtilities.findRequiredElement(
-        document,
-        "#iframe-wrapper"
-      );
-
-      return wrapper.scrollTop === 0;
+      return this.getScrollOffset() === 0;
     } else {
       const leftWidth = this.getLeftColumnsWidth();
       return leftWidth <= 0;
@@ -316,12 +312,8 @@ export default class ReflowableBookView implements BookView {
   // at bottom in scroll mode
   atEnd(): boolean {
     if (this.scrollMode) {
-      const wrapper = HTMLUtilities.findRequiredElement(
-        document,
-        "#iframe-wrapper"
-      );
       return (
-        Math.ceil(this.scrollingElement.scrollHeight - wrapper.scrollTop) - 1 <=
+        Math.ceil(this.getScrollExtent() - this.getScrollOffset()) - 1 <=
         BrowserUtilities.getHeight()
       );
     } else {
@@ -344,20 +336,11 @@ export default class ReflowableBookView implements BookView {
   }
 
   goToPreviousPage(): void {
-    const wrapper = HTMLUtilities.findRequiredElement(
-      document,
-      "#iframe-wrapper"
-    );
-
     if (this.scrollMode) {
-      const leftHeight = wrapper.scrollTop;
+      const leftHeight = this.getScrollOffset();
       const height = this.getScreenHeight() - 40;
       const offset = leftHeight - height;
-      if (offset >= 0) {
-        wrapper.scrollTop = offset;
-      } else {
-        wrapper.scrollTop = 0;
-      }
+      this.setScrollOffset(offset >= 0 ? offset : 0);
     } else {
       const leftWidth = this.getLeftColumnsWidth();
       const width = this.getColumnWidth();
@@ -375,21 +358,12 @@ export default class ReflowableBookView implements BookView {
   }
 
   goToNextPage(): void {
-    const wrapper = HTMLUtilities.findRequiredElement(
-      document,
-      "#iframe-wrapper"
-    );
-
     if (this.scrollMode) {
-      const leftHeight = wrapper.scrollTop;
+      const leftHeight = this.getScrollOffset();
       const height = this.getScreenHeight() - 40;
-      const scrollHeight = this.scrollingElement.scrollHeight;
+      const scrollHeight = this.getScrollExtent();
       const offset = leftHeight + height;
-      if (offset < scrollHeight) {
-        wrapper.scrollTop = offset;
-      } else {
-        wrapper.scrollTop = scrollHeight;
-      }
+      this.setScrollOffset(offset < scrollHeight ? offset : scrollHeight);
     } else {
       const leftWidth = this.getLeftColumnsWidth();
       const width = this.getColumnWidth();
@@ -487,7 +461,54 @@ export default class ReflowableBookView implements BookView {
     return wrapper.clientHeight;
   }
 
+  /**
+   * Which element provides the scrollbar in scroll mode.
+   *
+   * - `"host"` (default): `#iframe-wrapper` scrolls; iframe grows to content.
+   * - `"iframe"`: iframe's own document scrolls; iframe stays at viewport.
+   */
+  private get scrollContainerMode(): "host" | "iframe" {
+    return this.attributes?.scrollContainer === "iframe" ? "iframe" : "host";
+  }
+
+  /** Current scroll offset (px from top) of the active scroll container. */
+  private getScrollOffset(): number {
+    if (this.scrollContainerMode === "iframe") {
+      return this.scrollingElement?.scrollTop ?? 0;
+    }
+    const wrapper = HTMLUtilities.findRequiredElement(
+      document,
+      "#iframe-wrapper"
+    );
+    return wrapper.scrollTop;
+  }
+
+  /** Set scroll offset on the active scroll container. */
+  private setScrollOffset(value: number): void {
+    if (this.scrollContainerMode === "iframe") {
+      if (this.scrollingElement) this.scrollingElement.scrollTop = value;
+      return;
+    }
+    const wrapper = HTMLUtilities.findRequiredElement(
+      document,
+      "#iframe-wrapper"
+    );
+    wrapper.scrollTop = value;
+  }
+
+  /**
+   * Total scrollable height. Same value in both modes — iframe's internal
+   * document `scrollHeight`, because the iframe's document is always the
+   * source of truth for "how much content is there."
+   */
+  private getScrollExtent(): number {
+    return this.scrollingElement?.scrollHeight ?? 0;
+  }
+
   setIframeHeight(iframe: any) {
+    // Iframe-scroll mode keeps the iframe at viewport height; sizing is
+    // owned by `setSize()` and there is nothing to debounce-grow here.
+    if (this.scrollContainerMode === "iframe") return;
     let d = debounce((iframe: any) => {
       if (iframe) {
         let body = iframe.contentWindow.document.body,
@@ -531,12 +552,20 @@ export default class ReflowableBookView implements BookView {
   setSize(): void {
     this.iframe.width = BrowserUtilities.getWidth() + "px";
     if (!this.scrollMode) {
+      // Paginated: iframe and its document are constrained to the same
+      // height so columns fit the viewport.
       let doc = this.iframe.contentDocument;
       if (doc && doc.documentElement) {
         doc.documentElement.style.height = this.height + "px";
       }
       this.iframe.height = this.height + "px";
+    } else if (this.scrollContainerMode === "iframe") {
+      // Iframe-scroll: iframe stays at viewport height; its document is
+      // intentionally unconstrained so it overflows and scrolls inside
+      // the iframe.
+      this.iframe.height = this.height + "px";
     } else {
+      // Host-scroll: iframe grows to content; #iframe-wrapper scrolls.
       let html = this.iframe.contentWindow?.document?.documentElement;
       this.iframe.height = html?.offsetHeight + "px";
     }

--- a/viewer/index_dita.html
+++ b/viewer/index_dita.html
@@ -974,24 +974,21 @@
             //     credentials: "include",
             // },
             attributes: {
+                scrollContainer: "iframe",
                 // margin: 65,            // Extra px reserved below the iframe. Optional.
                 // iframePaddingTop: 20,  // @deprecated — use `iframe.padding.top`.
                 // Iframe CSS padding. Not applied to fixed-layout.
-                iframe: {
-                  padding: {
-                    bottom: 20
-                  }
-                },
+                // iframe: {
+                //   padding: {
+                //     bottom: 20
+                //   }
+                // },
                 // Fixed chrome the reader avoids for toolbox placement and iframe sizing.
                 // Measured live — toggling visibility reclaims the space automatically.
                 safeArea: {
                     top: () => document.querySelector('.mui-appbar'),
                     bottom: () => document.getElementById('reader-info-bottom'),
                 },
-                // `margin` not set — reader fills the iframe's parent container
-                // (`#iframe-wrapper`), whose CSS height (`calc(100vh - 140px)`)
-                // accounts for the 65px top bar and the 75px #reader-info-bottom
-                // strip below it.
             },
             rights: {
                 enableBookmarks: true,

--- a/viewer/index_injectables.html
+++ b/viewer/index_injectables.html
@@ -376,12 +376,6 @@
             url: new URL(urlParams['url']),
             injectables: injectables,
             injectablesFixed: [],
-            attributes: {
-              // Extra px reserved below the iframe. Optional.
-              margin: -40,
-              // @deprecated — use `iframe: { padding: { top: 20 } }`.
-              iframePaddingTop: 20,
-            },
             api: {
                 updateCurrentLocation: async function (loc) {
                     const title = loc.title || '';


### PR DESCRIPTION
Adds opt-in alternate viewport model for scroll mode. Default behaviour is unchanged.

## Highlights

- New `IFrameAttributes.scrollContainer?: "host" | "iframe"` (default `"host"`).
- `"iframe"` mode: iframe stays at viewport height (`wrapper.clientHeight − safeArea.bottom − iframe padding − margin`), iframe's own document scrolls internally. Prevents the 100%-height-chain feedback loop on cover pages and other content with `body { height: 100% }` injectables.
- `ReflowableBookView` refactored: scroll-source helpers (`getScrollOffset`, `setScrollOffset`, `getScrollExtent`, `scrollContainerMode`) route the six scroll-mode call sites; `setSize` / `setIframeHeight` / `setMode` branched per mode.
- Scroll handler attaches on `iframe.contentWindow.onscroll` in iframe mode, `wrapper.onscroll` in host mode. Re-attached on every chapter swap.
- Mode-aware iframe `scrolling` attribute (`"auto"` for iframe-scroll, `"no"` for host-scroll).

## Bonus fix

- `iframe.contentDocument.fonts.ready` await before reading-position restore in `handleIFrameLoad`. Reading-position restore previously ran 200ms after iframe load, but `@font-face` fonts arrive asynchronously after first paint and reflow the document — `scrollHeight` (scroll mode) and column widths (paginated) computed before fonts settle were stale, and the saved progression mapped to the wrong px / column. Resolves immediately when no fonts are pending.

## Default behaviour

Integrators with no `scrollContainer` set are byte-equivalent to pre-3.5.2.

## Recommended use

Set `scrollContainer: "iframe"` when integrator-supplied injectables style `body { height: 100% }` (cover pages) — the host-mode iframe-grows-to-content path triggers a feedback loop. Iframe-scroll mode is fixed-size and breaks the loop.

## Docs

- `docs/v3/CHANGES-v3-scroll-container.md` — internal notes.
- `docs/v3/MIGRATION-v3-scroll-container.md` — integrator-facing migration guide. Opt-in.

## Files changed

- `src/navigator/types.ts` — `scrollContainer` field on `IFrameAttributes`.
- `src/navigator/EpubNavigator.ts` — scroll event source branch, mode-aware `scrolling` attribute, `fonts.ready` await.
- `src/views/ReflowableBookView.ts` — helpers + branched scroll-mode paths + iframe sizing branch + scroll-mode start setup.

## Demo

`viewer/index_dita.html` enables `scrollContainer: "iframe"` so the canonical demo exercises the new mode.

## Ships as

`3.0.0-alpha.20`

## Test plan

- [x] DITA viewer demos — paginated and scroll modes render and navigate correctly.
- [x] Scroll mode with `scrollContainer: "iframe"` — iframe scrollbar appears inside iframe, wrapper does not scroll, scroll events drive position-save and atStart/atEnd.
- [x] Scroll mode with default `scrollContainer` (host) — unchanged from prior alpha.
- [x] Cover-page chapter (with `body { height: 100% }` injectable) — content renders without runaway iframe height in iframe-scroll mode.
- [x] Chapter swap in iframe-scroll mode — scroll resets to top of new chapter; previous chapter's scroll position does not leak.
- [x] Last reading position — restores correctly after page reload (especially for chapters with `@font-face` fonts).