### PR TITLE
fix(pagination): odd-column spacer mis-injection on refresh / back nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d-i-t-a/reader",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist-useragent-regexp": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-i-t-a/reader",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/d-i-t-a/R2D2BC",
   "license": "Apache-2.0",

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -1573,6 +1573,15 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             this.view?.goToCssSelector(startContainer);
           }
         } else if (bookViewPosition && bookViewPosition >= 0) {
+          // Inject the odd-column spacer before restoring progression so the
+          // progression-to-scroll math uses the final, even-column layout.
+          // Without this, refreshing on an odd-column page restores position
+          // against pre-spacer scrollWidth; then hideLoadingMessage adds the
+          // spacer and the visible content jumps right (or the chapter
+          // navigation lands on the wrong column).
+          if (this.view?.layout !== "fixed") {
+            this.view?.padOddColumns?.();
+          }
           this.view?.goToProgression(bookViewPosition);
         }
 
@@ -2965,6 +2974,12 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
             this.currentChapterLink.href + "#" + this.newElementId;
         }
 
+        // Inject the odd-column spacer before per-locator navigation so the
+        // progression-to-scroll math uses the even-column layout. Matches
+        // the fix in the initial-load path above.
+        if (this.view?.layout !== "fixed") {
+          this.view?.padOddColumns?.();
+        }
         if (this.newElementId) {
           for (const iframe of this.iframes) {
             const element = (iframe.contentDocument as any).getElementById(

--- a/src/views/ReflowableBookView.ts
+++ b/src/views/ReflowableBookView.ts
@@ -100,7 +100,13 @@ export default class ReflowableBookView implements BookView {
         }
       }
       this.setSize();
-      this.padOddColumns();
+      // padOddColumns intentionally NOT called here. Pre-settled layout at
+      // this point (mid-applyProperties, before fonts.ready / images, before
+      // multi-column flow has stabilized) produces non-deterministic
+      // remainder math — sometimes injects a spacer that isn't needed. The
+      // call sites in IFrameNavigator (initial-load and per-locator restore
+      // paths, plus hideLoadingMessage) all fire after layout has settled
+      // and handle this correctly.
     }
     if (this.navigator.rights.enableContentProtection) {
       this.navigator.contentProtectionModule?.recalculate();


### PR DESCRIPTION
## Summary
- Removes the `padOddColumns()` call from `ReflowableBookView.setMode` — it ran during `applyProperties` on pre-settled layout, producing transient `body.scrollWidth` measurements that injected the column spacer when content fit cleanly. Once injected, the existing-spacer early-return made the bad result sticky.
- Adds `padOddColumns()` calls before `goToProgression` in `IFrameNavigator` initial-load restore path and per-locator navigate path, where layout has had time to settle. Existing `hideLoadingMessage` call stays as a final safety net.

Fixes spacer either failing to appear or appearing incorrectly on odd-column chapters during refresh / back navigation.

## Test plan
- [x] Open a paginated EPUB with an odd-column chapter; confirm spacer renders on initial load.
- [x] Refresh on the last page of an odd-column chapter; confirm page count + position survive.
- [x] Navigate to next chapter and back; confirm spacer renders correctly each time.
- [x] Confirm chapters with floated content (cover-art etc.) still page-flip cleanly without phantom last column.